### PR TITLE
Restore swiper overflow clipping

### DIFF
--- a/index.html
+++ b/index.html
@@ -19,13 +19,8 @@
             --lime: #d2ff1e;
         }
 
-        .swiper {
-            overflow: visible !important;
-        }
-
-        /* Solo el wrapper deja salir los slides */
-        .swiper-wrapper {
-            overflow: visible !important;
+        .swiper-slide {
+            overflow: visible;
         }
 
         /* Efecto 3D controlado */


### PR DESCRIPTION
## Summary
- remove custom overflow visibility on the swiper container and wrapper to restore native clipping
- allow individual swiper slides to overflow so 3D card effects keep their breathing space

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68df3fd3f1d0832383bb21e155409144