### PR TITLE
Add Swiper carousel for featured properties

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,8 @@
       "dependencies": {
         "next": "15.5.4",
         "react": "19.1.0",
-        "react-dom": "19.1.0"
+        "react-dom": "19.1.0",
+        "swiper": "^11.1.7"
       },
       "devDependencies": {
         "@eslint/eslintrc": "^3",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
   "dependencies": {
     "react": "19.1.0",
     "react-dom": "19.1.0",
-    "next": "15.5.4"
+    "next": "15.5.4",
+    "swiper": "^11.1.7"
   },
   "devDependencies": {
     "typescript": "^5",

--- a/src/components/FeaturedProperties/PropertyCarousel.tsx
+++ b/src/components/FeaturedProperties/PropertyCarousel.tsx
@@ -1,0 +1,147 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+import type { RefObject } from "react";
+import { Swiper, SwiperSlide } from "swiper/react";
+import type { Swiper as SwiperInstance } from "swiper";
+import type { NavigationOptions, PaginationOptions } from "swiper/types";
+import { Navigation, Pagination } from "swiper/modules";
+
+import "swiper/css";
+import "swiper/css/navigation";
+import "swiper/css/pagination";
+
+export interface Property {
+  id: number;
+  title: string;
+  price: string;
+  status: string;
+  image: string;
+}
+
+interface PropertyCarouselProps {
+  properties: Property[];
+  navigationPrevRef: RefObject<HTMLElement>;
+  navigationNextRef: RefObject<HTMLElement>;
+  paginationRef: RefObject<HTMLElement>;
+}
+
+const PropertyCarousel = ({
+  properties,
+  navigationPrevRef,
+  navigationNextRef,
+  paginationRef,
+}: PropertyCarouselProps) => {
+  const swiperRef = useRef<SwiperInstance | null>(null);
+
+  useEffect(() => {
+    const swiper = swiperRef.current;
+
+    if (!swiper) {
+      return;
+    }
+
+    if (
+      swiper.params.navigation &&
+      typeof swiper.params.navigation !== "boolean" &&
+      navigationPrevRef.current &&
+      navigationNextRef.current
+    ) {
+      swiper.params.navigation = {
+        ...(swiper.params.navigation as NavigationOptions),
+        prevEl: navigationPrevRef.current,
+        nextEl: navigationNextRef.current,
+      };
+
+      swiper.navigation.destroy();
+      swiper.navigation.init();
+      swiper.navigation.update();
+    }
+
+    if (
+      swiper.params.pagination &&
+      typeof swiper.params.pagination !== "boolean" &&
+      paginationRef.current
+    ) {
+      swiper.params.pagination = {
+        ...(swiper.params.pagination as PaginationOptions),
+        el: paginationRef.current,
+        clickable: true,
+      };
+
+      swiper.pagination.destroy();
+      swiper.pagination.init();
+      swiper.pagination.render();
+      swiper.pagination.update();
+    }
+  }, [navigationPrevRef, navigationNextRef, paginationRef]);
+
+  return (
+    <Swiper
+      modules={[Navigation, Pagination]}
+      className="swiper mySwiper"
+      spaceBetween={30}
+      slidesPerView={1}
+      loop
+      navigation={{
+        prevEl: navigationPrevRef.current,
+        nextEl: navigationNextRef.current,
+      }}
+      pagination={{
+        el: paginationRef.current,
+        clickable: true,
+      }}
+      breakpoints={{
+        768: {
+          slidesPerView: 2,
+        },
+        1024: {
+          slidesPerView: 3,
+        },
+      }}
+      onBeforeInit={(swiper) => {
+        swiperRef.current = swiper;
+
+        if (typeof swiper.params.navigation !== "boolean") {
+          swiper.params.navigation.prevEl = navigationPrevRef.current;
+          swiper.params.navigation.nextEl = navigationNextRef.current;
+        }
+
+        if (typeof swiper.params.pagination !== "boolean") {
+          swiper.params.pagination.el = paginationRef.current;
+        }
+      }}
+      onSwiper={(swiper) => {
+        swiperRef.current = swiper;
+      }}
+    >
+      {properties.map((property) => (
+        <SwiperSlide key={property.id} className="swiper-slide">
+          <div className="card-3d overflow-hidden rounded-2xl bg-white shadow-md">
+            <div className="relative">
+              <img
+                src={property.image}
+                alt={property.title}
+                className="h-56 w-full object-cover"
+              />
+              <span className="absolute left-3 top-3 rounded-full bg-[var(--lime)] px-3 py-1 text-xs font-bold text-black">
+                {property.status}
+              </span>
+            </div>
+            <div className="p-6">
+              <h3 className="mb-2 text-xl font-semibold text-[var(--text-dark)]">
+                {property.title}
+              </h3>
+              <p className="mb-4 text-gray-600">{property.price}</p>
+              <a href="#" className="font-medium text-indigo-600 hover:underline">
+                Ver Detalles
+              </a>
+            </div>
+          </div>
+        </SwiperSlide>
+      ))}
+    </Swiper>
+  );
+};
+
+export default PropertyCarousel;

--- a/src/components/FeaturedProperties/index.tsx
+++ b/src/components/FeaturedProperties/index.tsx
@@ -1,4 +1,8 @@
-const properties = [
+import { useRef } from "react";
+
+import PropertyCarousel, { Property } from "./PropertyCarousel";
+
+const properties: Property[] = [
   {
     id: 1,
     title: "Residencia de lujo",
@@ -41,6 +45,10 @@ const properties = [
 ];
 
 const FeaturedProperties = () => {
+  const prevRef = useRef<HTMLButtonElement>(null);
+  const nextRef = useRef<HTMLButtonElement>(null);
+  const paginationRef = useRef<HTMLDivElement>(null);
+
   return (
     <section id="propiedades" className="bg-[#f1efeb] py-20">
       <div className="mx-auto max-w-7xl px-6">
@@ -50,39 +58,17 @@ const FeaturedProperties = () => {
 
         <div className="relative">
           <div className="swiper-container">
-            <div className="swiper mySwiper">
-              <div className="swiper-wrapper">
-                {properties.map((property) => (
-                  <div key={property.id} className="swiper-slide">
-                    <div className="card-3d overflow-hidden rounded-2xl bg-white shadow-md">
-                      <div className="relative">
-                        <img
-                          src={property.image}
-                          alt={property.title}
-                          className="h-56 w-full object-cover"
-                        />
-                        <span className="absolute left-3 top-3 rounded-full bg-[var(--lime)] px-3 py-1 text-xs font-bold text-black">
-                          {property.status}
-                        </span>
-                      </div>
-                      <div className="p-6">
-                        <h3 className="mb-2 text-xl font-semibold text-[var(--text-dark)]">
-                          {property.title}
-                        </h3>
-                        <p className="mb-4 text-gray-600">{property.price}</p>
-                        <a href="#" className="font-medium text-indigo-600 hover:underline">
-                          Ver Detalles
-                        </a>
-                      </div>
-                    </div>
-                  </div>
-                ))}
-              </div>
-            </div>
+            <PropertyCarousel
+              properties={properties}
+              navigationPrevRef={prevRef}
+              navigationNextRef={nextRef}
+              paginationRef={paginationRef}
+            />
           </div>
 
           <button
-            className="nav-prev text-[var(--indigo)] hover:text-black md:flex hidden absolute -left-16 top-1/2 z-20 h-12 w-12 -translate-y-1/2 items-center justify-center rounded-full bg-white/80 backdrop-blur-md shadow-xl transition hover:bg-[var(--lime)]"
+            ref={prevRef}
+            className="nav-prev absolute -left-16 top-1/2 z-20 hidden h-12 w-12 -translate-y-1/2 items-center justify-center rounded-full bg-white/80 text-[var(--indigo)] shadow-xl transition hover:bg-[var(--lime)] hover:text-black backdrop-blur-md md:flex"
             aria-label="Ver propiedad anterior"
             type="button"
           >
@@ -95,7 +81,8 @@ const FeaturedProperties = () => {
             </svg>
           </button>
           <button
-            className="nav-next text-[var(--indigo)] hover:text-black md:flex hidden absolute -right-16 top-1/2 z-20 h-12 w-12 -translate-y-1/2 items-center justify-center rounded-full bg-white/80 backdrop-blur-md shadow-xl transition hover:bg-[var(--lime)]"
+            ref={nextRef}
+            className="nav-next absolute -right-16 top-1/2 z-20 hidden h-12 w-12 -translate-y-1/2 items-center justify-center rounded-full bg-white/80 text-[var(--indigo)] shadow-xl transition hover:bg-[var(--lime)] hover:text-black backdrop-blur-md md:flex"
             aria-label="Ver siguiente propiedad"
             type="button"
           >
@@ -110,7 +97,7 @@ const FeaturedProperties = () => {
         </div>
 
         <div className="mt-8 flex justify-center md:hidden">
-          <div className="swiper-pagination !static" />
+          <div ref={paginationRef} className="swiper-pagination !static" />
         </div>
       </div>
     </section>


### PR DESCRIPTION
## Summary
- add the Swiper dependency to the project configuration
- create a PropertyCarousel client component that reproduces the featured property cards using Swiper with external controls
- integrate the carousel into the FeaturedProperties section while wiring the custom navigation and pagination refs

## Testing
- not run (per instructions)


------
https://chatgpt.com/codex/tasks/task_e_68df4a982e308323ac75dc66ecedd7c9