### PR TITLE
Enhance hero overlay and logo

### DIFF
--- a/src/components/HeroSection.tsx
+++ b/src/components/HeroSection.tsx
@@ -8,8 +8,13 @@ const HeroSection = () => {
           "url('https://hips.hearstapps.com/hmg-prod/images/interior-apartamentos-quay-nueva-york-torre-lujo7-1564380044.jpg')",
       }}
     >
-      <div className="absolute inset-0 bg-black/40" />
-      <div className="relative z-10 flex h-full max-w-2xl flex-col items-center justify-center px-4 text-center text-white">
+      <div className="absolute inset-0 bg-gradient-to-b from-black/60 via-black/40 to-black/60" />
+      <div className="relative z-10 flex h-full w-full max-w-2xl flex-col items-center justify-center px-6 text-center text-white md:px-8">
+        <img
+          src="/logo.png"
+          alt="Nombre inmobiliaria"
+          className="mb-6 h-20 w-auto md:h-24"
+        />
         <h1 className="mb-6 text-5xl font-bold drop-shadow-lg md:text-6xl">
           Vive el lujo que mereces
         </h1>


### PR DESCRIPTION
## Summary
- strengthen the hero overlay with a darker gradient for improved contrast
- add a centered responsive logo above the hero title and adjust spacing for various breakpoints

## Testing
- Not run (per instructions)

------
https://chatgpt.com/codex/tasks/task_e_68e08a15c77883239bc5fea67669a626