### PR TITLE
Add sizes attribute to navbar logo image

### DIFF
--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -29,13 +29,14 @@ const Navbar = () => {
 						onClick={closeMenu}
 					>
 						<div className="relative h-12 w-12 overflow-hidden rounded-full shadow-lg">
-							<Image
-								src="/logo.png"
-								alt="Villanueva García"
-								fill
-								className="object-contain"
-								priority
-							/>
+                                                        <Image
+                                                                src="/logo.png"
+                                                                alt="Villanueva García"
+                                                                fill
+                                                                sizes="48px"
+                                                                className="object-contain"
+                                                                priority
+                                                        />
 						</div>
 					</Link>
 


### PR DESCRIPTION
## Summary
- add the required sizes attribute to the navbar logo image so Next.js no longer warns about a missing value

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e09bae5b4c83238998addae79a6834