### PR TITLE
Add Prisma-backed properties API endpoint

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "inmobiliaria-frontend",
       "version": "0.1.0",
       "dependencies": {
+        "@prisma/client": "^5.22.0",
         "framer-motion": "^12.23.22",
         "lucide-react": "^0.544.0",
         "next": "15.5.4",

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "lint": "eslint"
   },
   "dependencies": {
+    "@prisma/client": "^5.22.0",
     "framer-motion": "^12.23.22",
     "lucide-react": "^0.544.0",
     "next": "15.5.4",

--- a/src/app/api/properties/route.ts
+++ b/src/app/api/properties/route.ts
@@ -1,0 +1,80 @@
+import { NextResponse } from 'next/server';
+
+import { prisma } from '@/lib/prisma';
+
+export async function GET() {
+  try {
+    const inmuebles = await prisma.inmueble.findMany({
+      include: {
+        estatus: true,
+        imagenes: {
+          orderBy: [{ orden: 'asc' }, { createdAt: 'asc' }],
+        },
+      },
+      orderBy: [
+        { esDestacado: 'desc' },
+        { createdAt: 'desc' },
+        { updatedAt: 'desc' },
+      ],
+    });
+
+    const properties = inmuebles.map((inmueble) => ({
+      id: inmueble.id.toString(),
+      title: inmueble.titulo,
+      slug: inmueble.slug,
+      description: inmueble.descripcion,
+      price: inmueble.precio.toNumber(),
+      address: inmueble.direccion,
+      neighborhood: inmueble.colonia,
+      city: inmueble.ciudad,
+      state: inmueble.estado,
+      postalCode: inmueble.codigoPostal,
+      location: {
+        latitude: inmueble.latitud?.toNumber() ?? null,
+        longitude: inmueble.longitud?.toNumber() ?? null,
+      },
+      rooms: inmueble.recamaras,
+      bathrooms: inmueble.banos?.toNumber() ?? null,
+      halfBathrooms: inmueble.mediosBanos,
+      parkingSpots: inmueble.estacionamientos,
+      landSizeM2: inmueble.m2Terreno?.toNumber() ?? null,
+      constructionSizeM2: inmueble.m2Construccion?.toNumber() ?? null,
+      age: inmueble.antiguedad,
+      furnished: inmueble.amueblado,
+      featured: inmueble.esDestacado,
+      active: inmueble.estaActivo,
+      type: inmueble.tipo,
+      operation: inmueble.operacion,
+      status: inmueble.estatus
+        ? {
+            id: inmueble.estatus.id,
+            name: inmueble.estatus.nombre,
+            color: inmueble.estatus.color,
+          }
+        : null,
+      images:
+        inmueble.imagenes?.map((imagen) => ({
+          id: imagen.id.toString(),
+          title: imagen.titulo,
+          description: imagen.descripcion,
+          order: imagen.orden,
+          isCover: imagen.esPortada,
+          isPublic: imagen.esPublica,
+          s3Key: imagen.s3Key,
+        })) ?? [],
+      createdAt: inmueble.createdAt.toISOString(),
+      updatedAt: inmueble.updatedAt.toISOString(),
+    }));
+
+    return NextResponse.json({ data: properties });
+  } catch (error) {
+    console.error('Error fetching properties', error);
+
+    return NextResponse.json(
+      {
+        error: 'Failed to fetch properties',
+      },
+      { status: 500 },
+    );
+  }
+}

--- a/src/lib/prisma.ts
+++ b/src/lib/prisma.ts
@@ -1,0 +1,18 @@
+import { PrismaClient } from '@prisma/client';
+
+const globalForPrisma = globalThis as unknown as {
+  prisma?: PrismaClient;
+};
+
+export const prisma =
+  globalForPrisma.prisma ??
+  new PrismaClient({
+    log:
+      process.env.NODE_ENV === 'development'
+        ? ['query', 'error', 'warn']
+        : ['error'],
+  });
+
+if (process.env.NODE_ENV !== 'production') {
+  globalForPrisma.prisma = prisma;
+}


### PR DESCRIPTION
## Summary
- create a reusable Prisma client helper for server routes
- add the properties API route that loads status and images with normalized output
- declare the Prisma client dependency for the project

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e0b3cd12908323b6cb8b455c62bcbb