### PR TITLE
Stop coercing bathrooms field to number

### DIFF
--- a/src/app/api/properties/route.ts
+++ b/src/app/api/properties/route.ts
@@ -34,7 +34,7 @@ export async function GET() {
         longitude: inmueble.longitud?.toNumber() ?? null,
       },
       rooms: inmueble.recamaras,
-      bathrooms: inmueble.banos?.toNumber() ?? null,
+      bathrooms: inmueble.banos ?? null,
       halfBathrooms: inmueble.mediosBanos,
       parkingSpots: inmueble.estacionamientos,
       landSizeM2: inmueble.m2Terreno?.toNumber() ?? null,


### PR DESCRIPTION
## Summary
- keep the bathrooms field coming from Prisma as-is instead of coercing it to a number before serializing the response

## Testing
- not run (per instructions)

------
https://chatgpt.com/codex/tasks/task_e_68e0c4a5d640832393b82f32ccf50ef4