### PR TITLE
Add S3 signed URLs for property images

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,15 @@
 This is a [Next.js](https://nextjs.org) project bootstrapped with [`create-next-app`](https://nextjs.org/docs/app/api-reference/cli/create-next-app).
 
+## Environment Variables
+
+Set the following variables to enable image delivery from Amazon S3:
+
+- `AWS_REGION`: AWS region where your public bucket lives.
+- `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY`: credentials with read access to the bucket.
+- `S3_PUBLIC_BUCKET`: name of the S3 bucket that stores public property images.
+
+When a signed URL cannot be generated or an image key is missing, the UI will fall back to the default image defined by `FALLBACK_IMAGE`.
+
 ## Getting Started
 
 First, run the development server:

--- a/package.json
+++ b/package.json
@@ -9,6 +9,8 @@
     "lint": "eslint"
   },
   "dependencies": {
+    "@aws-sdk/client-s3": "^3.726.1",
+    "@aws-sdk/s3-request-presigner": "^3.726.1",
     "@prisma/client": "^6.16.3",
     "framer-motion": "^12.23.22",
     "lucide-react": "^0.544.0",

--- a/src/app/api/properties/route.ts
+++ b/src/app/api/properties/route.ts
@@ -1,6 +1,9 @@
+import { GetObjectCommand } from '@aws-sdk/client-s3';
+import { getSignedUrl } from '@aws-sdk/s3-request-presigner';
 import { NextResponse } from 'next/server';
 
 import { prisma } from '@/lib/prisma';
+import { S3_PUBLIC_BUCKET, s3Client } from '@/lib/s3';
 
 export async function GET() {
   try {
@@ -18,53 +21,83 @@ export async function GET() {
       ],
     });
 
-    const properties = inmuebles.map((inmueble) => ({
-      id: inmueble.id.toString(),
-      title: inmueble.titulo,
-      slug: inmueble.slug,
-      description: inmueble.descripcion,
-      price: inmueble.precio.toNumber(),
-      address: inmueble.direccion,
-      neighborhood: inmueble.colonia,
-      city: inmueble.ciudad,
-      state: inmueble.estado,
-      postalCode: inmueble.codigoPostal,
-      location: {
-        latitude: inmueble.latitud?.toNumber() ?? null,
-        longitude: inmueble.longitud?.toNumber() ?? null,
-      },
-      rooms: inmueble.recamaras,
-      bathrooms: inmueble.banos ?? null,
-      halfBathrooms: inmueble.mediosBanos,
-      parkingSpots: inmueble.estacionamientos,
-      landSizeM2: inmueble.m2Terreno?.toNumber() ?? null,
-      constructionSizeM2: inmueble.m2Construccion?.toNumber() ?? null,
-      age: inmueble.antiguedad,
-      furnished: inmueble.amueblado,
-      featured: inmueble.destacado,
-      active: inmueble.estaActivo,
-      type: inmueble.tipo,
-      operation: inmueble.operacion,
-      status: inmueble.estatus
-        ? {
-            id: inmueble.estatus.id,
-            name: inmueble.estatus.nombre,
-            color: inmueble.estatus.color,
-          }
-        : null,
-      images:
-        inmueble.imagenes?.map((imagen) => ({
-          id: imagen.id.toString(),
-          title: imagen.titulo,
-          description: imagen.descripcion,
-          order: imagen.orden,
-          isCover: imagen.esPortada,
-          isPublic: imagen.esPublica,
-          s3Key: imagen.s3Key,
-        })) ?? [],
-      createdAt: inmueble.createdAt.toISOString(),
-      updatedAt: inmueble.updatedAt.toISOString(),
-    }));
+    const properties = await Promise.all(
+      inmuebles.map(async (inmueble) => {
+        const images = await Promise.all(
+          (inmueble.imagenes ?? []).map(async (imagen) => {
+            let signedUrl: string | null = null;
+
+            if (imagen.s3Key && S3_PUBLIC_BUCKET) {
+              try {
+                signedUrl = await getSignedUrl(
+                  s3Client,
+                  new GetObjectCommand({
+                    Bucket: S3_PUBLIC_BUCKET,
+                    Key: imagen.s3Key,
+                  }),
+                  { expiresIn: 3600 },
+                );
+              } catch (error) {
+                console.error(
+                  `Error generating signed URL for image ${imagen.id} with key ${imagen.s3Key}`,
+                  error,
+                );
+              }
+            }
+
+            return {
+              id: imagen.id.toString(),
+              title: imagen.titulo,
+              description: imagen.descripcion,
+              order: imagen.orden,
+              isCover: imagen.esPortada,
+              isPublic: imagen.esPublica,
+              s3Key: imagen.s3Key,
+              signedUrl,
+            };
+          }),
+        );
+
+        return {
+          id: inmueble.id.toString(),
+          title: inmueble.titulo,
+          slug: inmueble.slug,
+          description: inmueble.descripcion,
+          price: inmueble.precio.toNumber(),
+          address: inmueble.direccion,
+          neighborhood: inmueble.colonia,
+          city: inmueble.ciudad,
+          state: inmueble.estado,
+          postalCode: inmueble.codigoPostal,
+          location: {
+            latitude: inmueble.latitud?.toNumber() ?? null,
+            longitude: inmueble.longitud?.toNumber() ?? null,
+          },
+          rooms: inmueble.recamaras,
+          bathrooms: inmueble.banos ?? null,
+          halfBathrooms: inmueble.mediosBanos,
+          parkingSpots: inmueble.estacionamientos,
+          landSizeM2: inmueble.m2Terreno?.toNumber() ?? null,
+          constructionSizeM2: inmueble.m2Construccion?.toNumber() ?? null,
+          age: inmueble.antiguedad,
+          furnished: inmueble.amueblado,
+          featured: inmueble.destacado,
+          active: inmueble.estaActivo,
+          type: inmueble.tipo,
+          operation: inmueble.operacion,
+          status: inmueble.estatus
+            ? {
+                id: inmueble.estatus.id,
+                name: inmueble.estatus.nombre,
+                color: inmueble.estatus.color,
+              }
+            : null,
+          images,
+          createdAt: inmueble.createdAt.toISOString(),
+          updatedAt: inmueble.updatedAt.toISOString(),
+        };
+      }),
+    );
 
     return NextResponse.json({ data: properties });
   } catch (error) {

--- a/src/components/FeaturedProperties/index.tsx
+++ b/src/components/FeaturedProperties/index.tsx
@@ -6,6 +6,7 @@ import PropertyCarousel, { Property } from "./PropertyCarousel";
 
 interface ApiPropertyImage {
   s3Key: string;
+  signedUrl?: string | null;
   isCover?: boolean;
 }
 
@@ -25,27 +26,6 @@ interface ApiProperty {
 }
 
 const FALLBACK_IMAGE = "/1.png";
-
-const ensureAbsoluteImageUrl = (imageKey?: string): string => {
-  if (!imageKey) {
-    return FALLBACK_IMAGE;
-  }
-
-  if (imageKey.startsWith("http")) {
-    return imageKey;
-  }
-
-  const baseUrl = process.env.NEXT_PUBLIC_FILES_BASE_URL;
-
-  if (baseUrl) {
-    const sanitizedBase = baseUrl.endsWith("/") ? baseUrl.slice(0, -1) : baseUrl;
-    const sanitizedKey = imageKey.startsWith("/") ? imageKey.slice(1) : imageKey;
-
-    return `${sanitizedBase}/${sanitizedKey}`;
-  }
-
-  return imageKey || FALLBACK_IMAGE;
-};
 
 const formatOperation = (operation?: string | null) => {
   if (!operation) {
@@ -70,7 +50,7 @@ const mapPropertiesFromApi = (items: ApiProperty[]): Property[] =>
       price: item.price,
       operation: formatOperation(item.operation),
       status: item.status?.name ?? null,
-      coverImageUrl: ensureAbsoluteImageUrl(coverImage?.s3Key),
+      coverImageUrl: coverImage?.signedUrl ?? FALLBACK_IMAGE,
       location: locationParts.length > 0 ? locationParts.join(", ") : null,
     };
   });

--- a/src/lib/s3.ts
+++ b/src/lib/s3.ts
@@ -1,0 +1,18 @@
+import { S3Client } from "@aws-sdk/client-s3";
+
+const region = process.env.AWS_REGION;
+const accessKeyId = process.env.AWS_ACCESS_KEY_ID;
+const secretAccessKey = process.env.AWS_SECRET_ACCESS_KEY;
+
+export const S3_PUBLIC_BUCKET = process.env.S3_PUBLIC_BUCKET ?? "";
+
+export const s3Client = new S3Client({
+  region,
+  credentials:
+    accessKeyId && secretAccessKey
+      ? {
+          accessKeyId,
+          secretAccessKey,
+        }
+      : undefined,
+});


### PR DESCRIPTION
## Summary
- add AWS S3 client setup and document required environment variables
- generate signed URLs for property images returned by the properties API
- update the featured properties carousel to consume signed URLs with a fallback image

## Testing
- not run (per instructions)

------
https://chatgpt.com/codex/tasks/task_e_68e0c90f59e88323ba0b88e18bb86c4d