### PR TITLE
Update property carousel ref types

### DIFF
--- a/src/components/FeaturedProperties/PropertyCarousel.tsx
+++ b/src/components/FeaturedProperties/PropertyCarousel.tsx
@@ -29,9 +29,9 @@ export interface Property {
 
 interface PropertyCarouselProps {
   properties: Property[];
-  navigationPrevRef: RefObject<HTMLElement>;
-  navigationNextRef: RefObject<HTMLElement>;
-  paginationRef: RefObject<HTMLElement>;
+  navigationPrevRef: RefObject<HTMLButtonElement>;
+  navigationNextRef: RefObject<HTMLButtonElement>;
+  paginationRef: RefObject<HTMLDivElement>;
 }
 
 const PropertyCarousel = ({


### PR DESCRIPTION
## Summary
- update the property carousel navigation and pagination ref typings to use button and div elements instead of generic HTMLElement

## Testing
- not run (per instructions)

------
https://chatgpt.com/codex/tasks/task_e_68e1883621b08323a27c70c30943445c