### PR TITLE
Use dynamic loop configuration for property carousel

### DIFF
--- a/src/components/FeaturedProperties/PropertyCarousel.tsx
+++ b/src/components/FeaturedProperties/PropertyCarousel.tsx
@@ -41,6 +41,7 @@ const PropertyCarousel = ({
   paginationRef,
 }: PropertyCarouselProps) => {
   const swiperRef = useRef<SwiperInstance | null>(null);
+  const shouldLoop = properties.length > 3;
 
   useEffect(() => {
     const swiper = swiperRef.current;
@@ -90,7 +91,7 @@ const PropertyCarousel = ({
       className="swiper mySwiper"
       spaceBetween={30}
       slidesPerView={1}
-      loop
+      loop={shouldLoop}
       navigation={{
         prevEl: navigationPrevRef.current,
         nextEl: navigationNextRef.current,


### PR DESCRIPTION
## Summary
- add a reusable shouldLoop flag based on the properties count
- configure the Swiper instance to loop only when more than three items are available

## Testing
- not run (per instructions)

------
https://chatgpt.com/codex/tasks/task_e_68e188d8ebe883239d20a47b347681cd