### PR TITLE
Adjust property cards layout for carousel

### DIFF
--- a/src/components/FeaturedProperties/PropertyCarousel.tsx
+++ b/src/components/FeaturedProperties/PropertyCarousel.tsx
@@ -144,7 +144,7 @@ const PropertyCarousel = ({
 
         return (
           <SwiperSlide key={property.id} className="swiper-slide">
-            <div className="card-3d overflow-hidden rounded-2xl bg-white shadow-md">
+            <div className="card-3d flex h-full flex-col overflow-hidden rounded-2xl bg-white shadow-md">
               <div className="relative">
                 <img
                   src={property.coverImageUrl}
@@ -155,12 +155,12 @@ const PropertyCarousel = ({
                   {statusLabel}
                 </span>
               </div>
-              <div className="p-6">
-                <h3 className="mb-2 text-xl font-semibold text-[var(--text-dark)]">
+              <div className="flex h-full flex-col p-6">
+                <h3 className="mb-2 overflow-hidden text-ellipsis text-xl font-semibold text-[var(--text-dark)] whitespace-nowrap">
                   {property.title}
                 </h3>
                 <p className="mb-4 text-gray-600">{detailsLine}</p>
-                <a href="#" className="font-medium text-indigo-600 hover:underline">
+                <a href="#" className="mt-auto font-medium text-indigo-600 hover:underline">
                   Ver Detalles
                 </a>
               </div>


### PR DESCRIPTION
## Summary
- make each carousel card a full-height flex container to better fill the slide
- stack the card content vertically and pin the call-to-action link to the bottom
- truncate long property titles so they stay on a single line

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e18a07e6b48323a36264b1074425c6