### PR TITLE
feat: add inmuebles catalogue page

### DIFF
--- a/src/app/inmuebles/page.tsx
+++ b/src/app/inmuebles/page.tsx
@@ -1,0 +1,38 @@
+import type { Metadata } from "next";
+
+import Navbar from "@/components/Navbar";
+import Footer from "@/components/Footer";
+import ContactSection from "@/components/ContactSection";
+import InmueblesExplorer from "@/components/inmuebles/InmueblesExplorer";
+
+export const metadata: Metadata = {
+  title: "Catálogo de inmuebles | Villanueva García",
+  description:
+    "Explora las propiedades en venta y renta de Villanueva García. Filtra por ciudad, estatus y precio para encontrar tu próximo hogar.",
+};
+
+const InmueblesPage = () => {
+  return (
+    <div className="bg-[var(--bg-base)] text-[var(--text-dark)]">
+      <Navbar />
+      <main className="min-h-screen bg-[#f1efeb] pt-28 pb-20">
+        <section className="bg-gradient-to-br from-white/60 via-[#f1efeb] to-white/30">
+          <div className="mx-auto max-w-4xl px-6 py-12 text-center">
+            <h1 className="text-3xl font-bold text-[var(--text-dark)] md:text-4xl">
+              Propiedades disponibles
+            </h1>
+            <p className="mt-4 text-base text-gray-600 md:text-lg">
+              Descubre residencias exclusivas, departamentos y terrenos cuidadosamente
+              seleccionados. Ajusta los filtros para encontrar la propiedad ideal.
+            </p>
+          </div>
+        </section>
+        <InmueblesExplorer />
+        <ContactSection />
+      </main>
+      <Footer />
+    </div>
+  );
+};
+
+export default InmueblesPage;

--- a/src/components/FeaturedProperties/index.tsx
+++ b/src/components/FeaturedProperties/index.tsx
@@ -1,110 +1,19 @@
 "use client";
 
-import { useEffect, useRef, useState } from "react";
+import { useMemo, useRef } from "react";
 
-import PropertyCarousel, { Property } from "./PropertyCarousel";
-
-interface ApiPropertyImage {
-  s3Key: string;
-  signedUrl?: string | null;
-  isCover?: boolean;
-}
-
-interface ApiPropertyStatus {
-  name: string;
-}
-
-interface ApiProperty {
-  id: string;
-  title: string;
-  price: number;
-  operation?: string | null;
-  status?: ApiPropertyStatus | null;
-  city?: string | null;
-  state?: string | null;
-  images?: ApiPropertyImage[];
-}
-
-const FALLBACK_IMAGE = "/1.png";
-
-const formatOperation = (operation?: string | null) => {
-  if (!operation) {
-    return null;
-  }
-
-  const normalized = operation.toLowerCase();
-
-  return normalized.charAt(0).toUpperCase() + normalized.slice(1);
-};
-
-const mapPropertiesFromApi = (items: ApiProperty[]): Property[] =>
-  items.map((item) => {
-    const coverImage =
-      item.images?.find((image) => image.isCover) ?? item.images?.[0] ?? null;
-
-    const locationParts = [item.city, item.state].filter(Boolean) as string[];
-
-    return {
-      id: item.id,
-      title: item.title,
-      price: item.price,
-      operation: formatOperation(item.operation),
-      status: item.status?.name ?? null,
-      coverImageUrl: coverImage?.signedUrl ?? FALLBACK_IMAGE,
-      location: locationParts.length > 0 ? locationParts.join(", ") : null,
-    };
-  });
+import PropertyCarousel from "./PropertyCarousel";
+import { mapPropertiesFromApi, useProperties } from "./useProperties";
 
 const FeaturedProperties = () => {
   const prevRef = useRef<HTMLButtonElement>(null);
   const nextRef = useRef<HTMLButtonElement>(null);
   const paginationRef = useRef<HTMLDivElement>(null);
-  const [properties, setProperties] = useState<Property[]>([]);
-  const [isLoading, setIsLoading] = useState(true);
-  const [error, setError] = useState<string | null>(null);
-
-  useEffect(() => {
-    let isMounted = true;
-
-    const fetchProperties = async () => {
-      try {
-        setIsLoading(true);
-        setError(null);
-
-        const response = await fetch("/api/properties");
-
-        if (!response.ok) {
-          throw new Error("No se pudieron cargar las propiedades");
-        }
-
-        const { data } = await response.json();
-        const items = Array.isArray(data) ? data : [];
-
-        if (isMounted) {
-          setProperties(mapPropertiesFromApi(items));
-        }
-      } catch (fetchError) {
-        const message =
-          fetchError instanceof Error
-            ? fetchError.message
-            : "Ocurrió un error inesperado";
-
-        if (isMounted) {
-          setError(message);
-        }
-      } finally {
-        if (isMounted) {
-          setIsLoading(false);
-        }
-      }
-    };
-
-    fetchProperties();
-
-    return () => {
-      isMounted = false;
-    };
-  }, []);
+  const { properties: apiProperties, isLoading, error } = useProperties();
+  const properties = useMemo(
+    () => mapPropertiesFromApi(apiProperties),
+    [apiProperties],
+  );
 
   return (
     <section id="propiedades" className="bg-[#f1efeb] py-20">

--- a/src/components/FeaturedProperties/useProperties.ts
+++ b/src/components/FeaturedProperties/useProperties.ts
@@ -1,0 +1,107 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+import type { Property } from "./PropertyCarousel";
+
+export interface ApiPropertyImage {
+  s3Key: string;
+  signedUrl?: string | null;
+  isCover?: boolean;
+}
+
+export interface ApiPropertyStatus {
+  name: string;
+}
+
+export interface ApiProperty {
+  id: string;
+  title: string;
+  price: number;
+  operation?: string | null;
+  status?: ApiPropertyStatus | null;
+  city?: string | null;
+  state?: string | null;
+  images?: ApiPropertyImage[];
+}
+
+export const FALLBACK_IMAGE = "/1.png";
+
+export const formatOperation = (operation?: string | null) => {
+  if (!operation) {
+    return null;
+  }
+
+  const normalized = operation.toLowerCase();
+
+  return normalized.charAt(0).toUpperCase() + normalized.slice(1);
+};
+
+export const mapPropertiesFromApi = (items: ApiProperty[]): Property[] =>
+  items.map((item) => {
+    const coverImage =
+      item.images?.find((image) => image.isCover) ?? item.images?.[0] ?? null;
+
+    const locationParts = [item.city, item.state].filter(Boolean) as string[];
+
+    return {
+      id: item.id,
+      title: item.title,
+      price: item.price,
+      operation: formatOperation(item.operation),
+      status: item.status?.name ?? null,
+      coverImageUrl: coverImage?.signedUrl ?? FALLBACK_IMAGE,
+      location: locationParts.length > 0 ? locationParts.join(", ") : null,
+    };
+  });
+
+export const useProperties = () => {
+  const [properties, setProperties] = useState<ApiProperty[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let isMounted = true;
+
+    const fetchProperties = async () => {
+      try {
+        setIsLoading(true);
+        setError(null);
+
+        const response = await fetch("/api/properties");
+
+        if (!response.ok) {
+          throw new Error("No se pudieron cargar las propiedades");
+        }
+
+        const { data } = await response.json();
+        const items = Array.isArray(data) ? data : [];
+
+        if (isMounted) {
+          setProperties(items);
+        }
+      } catch (fetchError) {
+        const message =
+          fetchError instanceof Error
+            ? fetchError.message
+            : "Ocurrió un error inesperado";
+
+        if (isMounted) {
+          setError(message);
+        }
+      } finally {
+        if (isMounted) {
+          setIsLoading(false);
+        }
+      }
+    };
+
+    fetchProperties();
+
+    return () => {
+      isMounted = false;
+    };
+  }, []);
+
+  return { properties, isLoading, error };
+};

--- a/src/components/inmuebles/FiltersBar.tsx
+++ b/src/components/inmuebles/FiltersBar.tsx
@@ -1,0 +1,150 @@
+"use client";
+
+const viewOptions = [
+  { value: "list" as const, label: "Lista" },
+  { value: "grid" as const, label: "Cuadrícula" },
+];
+
+export type ViewMode = (typeof viewOptions)[number]["value"];
+
+export type SortOption = "relevance" | "price-asc" | "price-desc";
+
+interface FiltersBarProps {
+  totalCount: number;
+  isLoading: boolean;
+  viewMode: ViewMode;
+  onViewModeChange: (mode: ViewMode) => void;
+  sortOption: SortOption;
+  onSortChange: (option: SortOption) => void;
+  operationFilter: string;
+  onOperationChange: (operation: string) => void;
+  availableOperations: string[];
+  statusFilter: string;
+  onStatusChange: (status: string) => void;
+  availableStatuses: string[];
+  searchTerm: string;
+  onSearchChange: (value: string) => void;
+}
+
+const FiltersBar = ({
+  totalCount,
+  isLoading,
+  viewMode,
+  onViewModeChange,
+  sortOption,
+  onSortChange,
+  operationFilter,
+  onOperationChange,
+  availableOperations,
+  statusFilter,
+  onStatusChange,
+  availableStatuses,
+  searchTerm,
+  onSearchChange,
+}: FiltersBarProps) => {
+  return (
+    <section className="rounded-3xl bg-white/80 p-6 shadow-lg backdrop-blur">
+      <div className="flex flex-col gap-6 md:flex-row md:items-center md:justify-between">
+        <div>
+          <p className="text-sm uppercase tracking-wide text-gray-500">
+            {isLoading ? "Cargando propiedades…" : `Mostrando ${totalCount} propiedades`}
+          </p>
+          <h1 className="text-2xl font-semibold text-[var(--text-dark)]">
+            Encuentra tu próximo hogar
+          </h1>
+        </div>
+
+        <div className="flex flex-wrap items-center gap-3">
+          {viewOptions.map((option) => {
+            const isActive = option.value === viewMode;
+
+            return (
+              <button
+                key={option.value}
+                type="button"
+                onClick={() => onViewModeChange(option.value)}
+                aria-pressed={isActive}
+                className={`flex items-center gap-2 rounded-full border px-4 py-2 text-sm font-medium transition focus:outline-none focus:ring-2 focus:ring-[var(--indigo)] focus:ring-offset-2 ${
+                  isActive
+                    ? "border-[var(--indigo)] bg-[var(--indigo)] text-white"
+                    : "border-gray-200 bg-white text-[var(--text-dark)] hover:border-[var(--indigo)] hover:text-[var(--indigo)]"
+                }`}
+              >
+                <span
+                  className="inline-flex h-2.5 w-2.5 rounded-full border border-current"
+                  aria-hidden="true"
+                />
+                {option.label}
+              </button>
+            );
+          })}
+        </div>
+      </div>
+
+      <div className="mt-6 grid gap-4 md:grid-cols-4">
+        <label className="flex flex-col text-sm font-medium text-[var(--text-dark)]">
+          Operación
+          <select
+            value={operationFilter}
+            onChange={(event) => onOperationChange(event.target.value)}
+            className="mt-2 rounded-xl border border-gray-200 bg-white px-4 py-2 text-[var(--text-dark)] focus:border-[var(--indigo)] focus:outline-none focus:ring-2 focus:ring-[var(--indigo)]"
+          >
+            <option value="all">Todas</option>
+            {availableOperations.map((operation) => (
+              <option key={operation} value={operation}>
+                {operation}
+              </option>
+            ))}
+          </select>
+        </label>
+
+        <label className="flex flex-col text-sm font-medium text-[var(--text-dark)]">
+          Estatus
+          <select
+            value={statusFilter}
+            onChange={(event) => onStatusChange(event.target.value)}
+            className="mt-2 rounded-xl border border-gray-200 bg-white px-4 py-2 text-[var(--text-dark)] focus:border-[var(--indigo)] focus:outline-none focus:ring-2 focus:ring-[var(--indigo)]"
+          >
+            <option value="all">Todos</option>
+            {availableStatuses.map((status) => (
+              <option key={status} value={status}>
+                {status}
+              </option>
+            ))}
+          </select>
+        </label>
+
+        <label className="flex flex-col text-sm font-medium text-[var(--text-dark)]">
+          Ordenar por
+          <select
+            value={sortOption}
+            onChange={(event) => onSortChange(event.target.value as SortOption)}
+            className="mt-2 rounded-xl border border-gray-200 bg-white px-4 py-2 text-[var(--text-dark)] focus:border-[var(--indigo)] focus:outline-none focus:ring-2 focus:ring-[var(--indigo)]"
+          >
+            <option value="relevance">Relevancia</option>
+            <option value="price-desc">Precio: Mayor a menor</option>
+            <option value="price-asc">Precio: Menor a mayor</option>
+          </select>
+        </label>
+
+        <label className="flex flex-col text-sm font-medium text-[var(--text-dark)]">
+          Buscar
+          <div className="mt-2 flex items-center gap-2 rounded-xl border border-gray-200 bg-white px-4 py-2 focus-within:border-[var(--indigo)] focus-within:ring-2 focus-within:ring-[var(--indigo)]">
+            <span className="text-gray-400" aria-hidden="true">
+              🔍
+            </span>
+            <input
+              type="search"
+              value={searchTerm}
+              placeholder="Ciudad, estado o título"
+              onChange={(event) => onSearchChange(event.target.value)}
+              className="w-full border-none bg-transparent text-[var(--text-dark)] outline-none"
+            />
+          </div>
+        </label>
+      </div>
+    </section>
+  );
+};
+
+export default FiltersBar;

--- a/src/components/inmuebles/InmueblesExplorer.tsx
+++ b/src/components/inmuebles/InmueblesExplorer.tsx
@@ -1,0 +1,133 @@
+"use client";
+
+import { useMemo, useState } from "react";
+
+import FiltersBar, { type SortOption, type ViewMode } from "./FiltersBar";
+import PropertiesList from "./PropertiesList";
+import { useProperties } from "@/components/FeaturedProperties/useProperties";
+
+const normalizeValue = (value?: string | null) => value?.trim().toLowerCase() ?? "";
+
+const InmueblesExplorer = () => {
+  const { properties, isLoading, error } = useProperties();
+  const [viewMode, setViewMode] = useState<ViewMode>("list");
+  const [operationFilter, setOperationFilter] = useState("all");
+  const [statusFilter, setStatusFilter] = useState("all");
+  const [sortOption, setSortOption] = useState<SortOption>("relevance");
+  const [searchTerm, setSearchTerm] = useState("");
+
+  const availableOperations = useMemo(() => {
+    const unique = new Set<string>();
+
+    properties.forEach((property) => {
+      if (property.operation) {
+        unique.add(property.operation);
+      }
+    });
+
+    return Array.from(unique).sort((a, b) => a.localeCompare(b));
+  }, [properties]);
+
+  const availableStatuses = useMemo(() => {
+    const unique = new Set<string>();
+
+    properties.forEach((property) => {
+      if (property.status?.name) {
+        unique.add(property.status.name);
+      }
+    });
+
+    return Array.from(unique).sort((a, b) => a.localeCompare(b));
+  }, [properties]);
+
+  const filteredProperties = useMemo(() => {
+    const normalizedSearch = normalizeValue(searchTerm);
+
+    return properties.filter((property) => {
+      const normalizedOperation = normalizeValue(property.operation);
+      const normalizedStatus = normalizeValue(property.status?.name ?? null);
+      const matchesOperation =
+        operationFilter === "all" || normalizedOperation === normalizeValue(operationFilter);
+      const matchesStatus =
+        statusFilter === "all" || normalizedStatus === normalizeValue(statusFilter);
+
+      const matchesSearch =
+        normalizedSearch.length === 0 ||
+        [property.title, property.city, property.state]
+          .filter(Boolean)
+          .some((field) => normalizeValue(field).includes(normalizedSearch));
+
+      return matchesOperation && matchesStatus && matchesSearch;
+    });
+  }, [operationFilter, properties, searchTerm, statusFilter]);
+
+  const sortedProperties = useMemo(() => {
+    if (sortOption === "relevance") {
+      return filteredProperties;
+    }
+
+    const copy = [...filteredProperties];
+
+    copy.sort((a, b) => {
+      const priceA = Number.isFinite(a.price) ? a.price : 0;
+      const priceB = Number.isFinite(b.price) ? b.price : 0;
+
+      if (sortOption === "price-asc") {
+        return priceA - priceB;
+      }
+
+      if (sortOption === "price-desc") {
+        return priceB - priceA;
+      }
+
+      return 0;
+    });
+
+    return copy;
+  }, [filteredProperties, sortOption]);
+
+  return (
+    <div className="mx-auto flex max-w-7xl flex-col gap-10 px-6 py-12">
+      <FiltersBar
+        totalCount={sortedProperties.length}
+        isLoading={isLoading}
+        viewMode={viewMode}
+        onViewModeChange={setViewMode}
+        sortOption={sortOption}
+        onSortChange={setSortOption}
+        operationFilter={operationFilter}
+        onOperationChange={setOperationFilter}
+        availableOperations={availableOperations}
+        statusFilter={statusFilter}
+        onStatusChange={setStatusFilter}
+        availableStatuses={availableStatuses}
+        searchTerm={searchTerm}
+        onSearchChange={setSearchTerm}
+      />
+
+      {isLoading && (
+        <div className="flex min-h-[200px] items-center justify-center rounded-3xl bg-white/70 p-10 text-center text-gray-500">
+          Cargando propiedades…
+        </div>
+      )}
+
+      {error && !isLoading && (
+        <div className="rounded-3xl border border-red-200 bg-red-50 p-6 text-center text-red-700">
+          {error}
+        </div>
+      )}
+
+      {!isLoading && !error && sortedProperties.length === 0 && (
+        <div className="flex min-h-[200px] items-center justify-center rounded-3xl bg-white/70 p-10 text-center text-gray-500">
+          No hay propiedades destacadas disponibles por ahora.
+        </div>
+      )}
+
+      {!isLoading && !error && sortedProperties.length > 0 && (
+        <PropertiesList properties={sortedProperties} viewMode={viewMode} />
+      )}
+    </div>
+  );
+};
+
+export default InmueblesExplorer;

--- a/src/components/inmuebles/PropertiesList.tsx
+++ b/src/components/inmuebles/PropertiesList.tsx
@@ -1,0 +1,30 @@
+import PropertyCard from "./PropertyCard";
+import type { ViewMode } from "./FiltersBar";
+import type { ApiProperty } from "@/components/FeaturedProperties/useProperties";
+
+interface PropertiesListProps {
+  properties: ApiProperty[];
+  viewMode: ViewMode;
+}
+
+const PropertiesList = ({ properties, viewMode }: PropertiesListProps) => {
+  if (properties.length === 0) {
+    return null;
+  }
+
+  return (
+    <div
+      className={
+        viewMode === "grid"
+          ? "grid gap-6 md:grid-cols-2"
+          : "flex flex-col gap-6"
+      }
+    >
+      {properties.map((property) => (
+        <PropertyCard key={property.id} property={property} viewMode={viewMode} />
+      ))}
+    </div>
+  );
+};
+
+export default PropertiesList;

--- a/src/components/inmuebles/PropertyCard.tsx
+++ b/src/components/inmuebles/PropertyCard.tsx
@@ -1,0 +1,136 @@
+import { FALLBACK_IMAGE } from "@/components/FeaturedProperties/useProperties";
+import type { ApiProperty } from "@/components/FeaturedProperties/useProperties";
+import type { ViewMode } from "./FiltersBar";
+
+const currencyFormatter = new Intl.NumberFormat("es-MX", {
+  style: "currency",
+  currency: "MXN",
+  maximumFractionDigits: 0,
+});
+
+interface PropertyCardProps {
+  property: ApiProperty;
+  viewMode: ViewMode;
+}
+
+const getLocationLabel = (property: ApiProperty) => {
+  const locationParts = [property.city, property.state].filter(Boolean);
+
+  return locationParts.length > 0 ? locationParts.join(", ") : null;
+};
+
+const getPrimaryImage = (property: ApiProperty) => {
+  const coverImage = property.images?.find((image) => image.isCover);
+
+  if (coverImage?.signedUrl) {
+    return coverImage.signedUrl;
+  }
+
+  const firstImage = property.images?.[0];
+
+  return firstImage?.signedUrl ?? FALLBACK_IMAGE;
+};
+
+const PropertyCard = ({ property, viewMode }: PropertyCardProps) => {
+  const imageUrl = getPrimaryImage(property);
+  const locationLabel = getLocationLabel(property);
+  const formattedPrice = Number.isFinite(property.price)
+    ? currencyFormatter.format(property.price)
+    : "Consultar";
+
+  const statusLabel = property.status?.name ?? property.operation ?? "Disponible";
+  const operationLabel = property.operation ?? "";
+  const whatsappMessage = encodeURIComponent(
+    `Hola, me interesa la propiedad "${property.title}" (${formattedPrice}).`
+  );
+
+  const whatsappHref = `https://wa.me/?text=${whatsappMessage}`;
+
+  const isListMode = viewMode === "list";
+  const baseArticleClasses =
+    "card-3d flex flex-col overflow-hidden rounded-3xl bg-white shadow-lg transition hover:-translate-y-1 hover:shadow-2xl";
+  const articleClasses = isListMode
+    ? `${baseArticleClasses} md:h-80 md:flex-row`
+    : baseArticleClasses;
+  const imageWrapperClasses = isListMode
+    ? "relative w-full shrink-0 md:w-5/12"
+    : "relative w-full shrink-0";
+  const imageClasses = isListMode
+    ? "h-64 w-full object-cover md:h-full"
+    : "h-56 w-full object-cover";
+
+  return (
+    <article className={articleClasses}>
+      <div className={imageWrapperClasses}>
+        <img src={imageUrl} alt={property.title} className={imageClasses} />
+
+        <div className="absolute left-3 top-3 flex flex-wrap gap-2">
+          <span className="rounded-full bg-[var(--lime)] px-3 py-1 text-xs font-semibold text-black">
+            {statusLabel}
+          </span>
+          {operationLabel && (
+            <span className="rounded-full bg-black/70 px-3 py-1 text-xs font-semibold text-white">
+              {operationLabel}
+            </span>
+          )}
+        </div>
+      </div>
+
+      <div className="flex flex-1 flex-col justify-between gap-6 p-6">
+        <div className="space-y-3">
+          <h3 className="text-xl font-semibold text-[var(--text-dark)]">
+            {property.title}
+          </h3>
+
+          {locationLabel && (
+            <p className="flex items-center gap-2 text-sm text-gray-500">
+              <span aria-hidden="true">📍</span>
+              {locationLabel}
+            </p>
+          )}
+
+          <p className="text-lg font-bold text-[var(--indigo)]">{formattedPrice}</p>
+
+          <div className="flex flex-wrap gap-3 text-sm text-gray-600">
+            {property.status?.name && (
+              <span className="rounded-full bg-gray-100 px-3 py-1 font-medium">
+                {property.status.name}
+              </span>
+            )}
+            {property.operation && (
+              <span className="rounded-full bg-gray-100 px-3 py-1 font-medium">
+                {property.operation}
+              </span>
+            )}
+            <span className="rounded-full bg-gray-100 px-3 py-1 font-medium">
+              ID: {property.id}
+            </span>
+          </div>
+        </div>
+
+        <div
+          className={`flex flex-col gap-3 text-sm font-semibold md:flex-row ${
+            isListMode ? "md:items-center" : ""
+          }`}
+        >
+          <a
+            href="#contacto"
+            className="flex-1 rounded-full bg-[var(--indigo)] px-5 py-3 text-center text-white transition hover:bg-[var(--lime)] hover:text-black"
+          >
+            Contactar asesor
+          </a>
+          <a
+            href={whatsappHref}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="flex-1 rounded-full border border-[var(--indigo)] px-5 py-3 text-center text-[var(--indigo)] transition hover:bg-[var(--indigo)] hover:text-white"
+          >
+            Hablar por WhatsApp
+          </a>
+        </div>
+      </div>
+    </article>
+  );
+};
+
+export default PropertyCard;


### PR DESCRIPTION
## Summary
- add a reusable `useProperties` hook so the carousel and catalog share data fetching and fallback mapping
- introduce a new `/inmuebles` app-router page with hero copy, SEO metadata, and contact CTA
- build catalog UI pieces (filters bar, list, and cards) to browse properties responsively with loading and empty states

## Testing
- npm run dev

------
https://chatgpt.com/codex/tasks/task_e_68e1d6cffa7c832380a43be7b574ff3d