### PR TITLE
Enhance styling of the filters bar

### DIFF
--- a/src/components/inmuebles/FiltersBar.tsx
+++ b/src/components/inmuebles/FiltersBar.tsx
@@ -82,12 +82,24 @@ const FiltersBar = ({
       </div>
 
       <div className="mt-6 grid gap-4 md:grid-cols-4">
-        <label className="flex flex-col text-sm font-medium text-[var(--text-dark)]">
-          Operación
+        <div className="rounded-2xl bg-slate-50/90 p-4 shadow-sm transition hover:shadow-md">
+          <div className="flex items-center gap-3 text-[var(--text-dark)]">
+            <span className="flex h-10 w-10 items-center justify-center rounded-full bg-white text-xl shadow-sm" aria-hidden="true">
+              🏠
+            </span>
+            <div>
+              <p className="text-xs font-semibold uppercase tracking-wide text-gray-500">Operación</p>
+              <p className="text-sm text-gray-600">Tipo de operación</p>
+            </div>
+          </div>
+          <label htmlFor="operation-filter" className="sr-only">
+            Selecciona el tipo de operación
+          </label>
           <select
+            id="operation-filter"
             value={operationFilter}
             onChange={(event) => onOperationChange(event.target.value)}
-            className="mt-2 rounded-xl border border-gray-200 bg-white px-4 py-2 text-[var(--text-dark)] focus:border-[var(--indigo)] focus:outline-none focus:ring-2 focus:ring-[var(--indigo)]"
+            className="mt-4 w-full rounded-xl border border-gray-200 bg-white px-4 py-2 text-[var(--text-dark)] shadow-sm transition focus:border-[var(--indigo)] focus:outline-none focus:ring-2 focus:ring-[var(--indigo)] focus:ring-offset-2 hover:border-[var(--indigo)]"
           >
             <option value="all">Todas</option>
             {availableOperations.map((operation) => (
@@ -96,14 +108,26 @@ const FiltersBar = ({
               </option>
             ))}
           </select>
-        </label>
+        </div>
 
-        <label className="flex flex-col text-sm font-medium text-[var(--text-dark)]">
-          Estatus
+        <div className="rounded-2xl bg-slate-50/90 p-4 shadow-sm transition hover:shadow-md">
+          <div className="flex items-center gap-3 text-[var(--text-dark)]">
+            <span className="flex h-10 w-10 items-center justify-center rounded-full bg-white text-xl shadow-sm" aria-hidden="true">
+              📊
+            </span>
+            <div>
+              <p className="text-xs font-semibold uppercase tracking-wide text-gray-500">Estatus</p>
+              <p className="text-sm text-gray-600">Disponibilidad del inmueble</p>
+            </div>
+          </div>
+          <label htmlFor="status-filter" className="sr-only">
+            Selecciona el estatus del inmueble
+          </label>
           <select
+            id="status-filter"
             value={statusFilter}
             onChange={(event) => onStatusChange(event.target.value)}
-            className="mt-2 rounded-xl border border-gray-200 bg-white px-4 py-2 text-[var(--text-dark)] focus:border-[var(--indigo)] focus:outline-none focus:ring-2 focus:ring-[var(--indigo)]"
+            className="mt-4 w-full rounded-xl border border-gray-200 bg-white px-4 py-2 text-[var(--text-dark)] shadow-sm transition focus:border-[var(--indigo)] focus:outline-none focus:ring-2 focus:ring-[var(--indigo)] focus:ring-offset-2 hover:border-[var(--indigo)]"
           >
             <option value="all">Todos</option>
             {availableStatuses.map((status) => (
@@ -112,36 +136,57 @@ const FiltersBar = ({
               </option>
             ))}
           </select>
-        </label>
+        </div>
 
-        <label className="flex flex-col text-sm font-medium text-[var(--text-dark)]">
-          Ordenar por
+        <div className="rounded-2xl bg-slate-50/90 p-4 shadow-sm transition hover:shadow-md">
+          <div className="flex items-center gap-3 text-[var(--text-dark)]">
+            <span className="flex h-10 w-10 items-center justify-center rounded-full bg-white text-xl shadow-sm" aria-hidden="true">
+              ⚖️
+            </span>
+            <div>
+              <p className="text-xs font-semibold uppercase tracking-wide text-gray-500">Ordenar por</p>
+              <p className="text-sm text-gray-600">Define la prioridad de la lista</p>
+            </div>
+          </div>
+          <label htmlFor="sort-filter" className="sr-only">
+            Selecciona el orden de los resultados
+          </label>
           <select
+            id="sort-filter"
             value={sortOption}
             onChange={(event) => onSortChange(event.target.value as SortOption)}
-            className="mt-2 rounded-xl border border-gray-200 bg-white px-4 py-2 text-[var(--text-dark)] focus:border-[var(--indigo)] focus:outline-none focus:ring-2 focus:ring-[var(--indigo)]"
+            className="mt-4 w-full rounded-xl border border-gray-200 bg-white px-4 py-2 text-[var(--text-dark)] shadow-sm transition focus:border-[var(--indigo)] focus:outline-none focus:ring-2 focus:ring-[var(--indigo)] focus:ring-offset-2 hover:border-[var(--indigo)]"
           >
             <option value="relevance">Relevancia</option>
             <option value="price-desc">Precio: Mayor a menor</option>
             <option value="price-asc">Precio: Menor a mayor</option>
           </select>
-        </label>
+        </div>
 
-        <label className="flex flex-col text-sm font-medium text-[var(--text-dark)]">
-          Buscar
-          <div className="mt-2 flex items-center gap-2 rounded-xl border border-gray-200 bg-white px-4 py-2 focus-within:border-[var(--indigo)] focus-within:ring-2 focus-within:ring-[var(--indigo)]">
-            <span className="text-gray-400" aria-hidden="true">
+        <div className="rounded-2xl bg-slate-50/90 p-4 shadow-sm transition hover:shadow-md">
+          <div className="flex items-center gap-3 text-[var(--text-dark)]">
+            <span className="flex h-10 w-10 items-center justify-center rounded-full bg-white text-xl shadow-sm" aria-hidden="true">
               🔍
             </span>
+            <div>
+              <p className="text-xs font-semibold uppercase tracking-wide text-gray-500">Buscar</p>
+              <p className="text-sm text-gray-600">Explora por ubicación o título</p>
+            </div>
+          </div>
+          <label htmlFor="search-term" className="sr-only">
+            Ingresa un término de búsqueda
+          </label>
+          <div className="mt-4 flex items-center gap-2 rounded-xl border border-gray-200 bg-white px-4 py-2 shadow-sm transition focus-within:border-[var(--indigo)] focus-within:outline-none focus-within:ring-2 focus-within:ring-[var(--indigo)] focus-within:ring-offset-2">
             <input
+              id="search-term"
               type="search"
               value={searchTerm}
               placeholder="Ciudad, estado o título"
               onChange={(event) => onSearchChange(event.target.value)}
-              className="w-full border-none bg-transparent text-[var(--text-dark)] outline-none"
+              className="w-full border-none bg-transparent text-[var(--text-dark)] placeholder:text-gray-400 outline-none focus:ring-0"
             />
           </div>
-        </label>
+        </div>
       </div>
     </section>
   );


### PR DESCRIPTION
## Summary
- wrap each filters bar control in a soft card container with iconography and supporting titles
- update selects and the search input to use full-width layouts, white backgrounds, and hover/focus emphasis
- ensure focus/hover states stay consistent for accessible interaction cues

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e1dd49c2208323ba36e82ef4ed11d7