### PR TITLE
Adjust inmobiliaria spacing responsiveness

### DIFF
--- a/src/app/inmuebles/page.tsx
+++ b/src/app/inmuebles/page.tsx
@@ -15,9 +15,9 @@ const InmueblesPage = () => {
   return (
     <div className="bg-[var(--bg-base)] text-[var(--text-dark)]">
       <Navbar />
-      <main className="min-h-screen bg-[#f1efeb] pt-28 pb-20">
+      <main className="min-h-screen bg-[#f1efeb] pt-20 pb-16 md:pt-28 md:pb-20">
         <section className="bg-gradient-to-br from-white/60 via-[#f1efeb] to-white/30">
-          <div className="mx-auto max-w-4xl px-6 py-12 text-center">
+          <div className="mx-auto max-w-4xl px-6 py-8 text-center md:py-12">
             <h1 className="text-3xl font-bold text-[var(--text-dark)] md:text-4xl">
               Propiedades disponibles
             </h1>

--- a/src/components/inmuebles/InmueblesExplorer.tsx
+++ b/src/components/inmuebles/InmueblesExplorer.tsx
@@ -87,7 +87,7 @@ const InmueblesExplorer = () => {
   }, [filteredProperties, sortOption]);
 
   return (
-    <div className="mx-auto flex max-w-7xl flex-col gap-10 px-6 py-12">
+    <div className="mx-auto flex max-w-7xl flex-col gap-10 px-6 py-8 md:py-12">
       <FiltersBar
         totalCount={sortedProperties.length}
         isLoading={isLoading}


### PR DESCRIPTION
## Summary
- tighten top and bottom spacing on the inmuebles page for small screens while preserving desktop padding
- reduce hero section vertical padding on mobile with responsive utility classes
- align the explorer container spacing with a smaller mobile padding and desktop defaults

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e1de21780c8323af80c6606efe18ec