### PR TITLE
Update property cards to use slug-based detail links

### DIFF
--- a/src/components/FeaturedProperties/PropertyCarousel.tsx
+++ b/src/components/FeaturedProperties/PropertyCarousel.tsx
@@ -20,6 +20,7 @@ const currencyFormatter = new Intl.NumberFormat("es-MX", {
 export interface Property {
   id: string;
   title: string;
+  slug?: string | null;
   price: number;
   operation?: string | null;
   status?: string | null;

--- a/src/components/FeaturedProperties/useProperties.ts
+++ b/src/components/FeaturedProperties/useProperties.ts
@@ -17,6 +17,7 @@ export interface ApiPropertyStatus {
 export interface ApiProperty {
   id: string;
   title: string;
+  slug: string;
   price: number;
   operation?: string | null;
   status?: ApiPropertyStatus | null;
@@ -47,6 +48,7 @@ export const mapPropertiesFromApi = (items: ApiProperty[]): Property[] =>
     return {
       id: item.id,
       title: item.title,
+      slug: item.slug,
       price: item.price,
       operation: formatOperation(item.operation),
       status: item.status?.name ?? null,

--- a/src/components/inmuebles/PropertyCard.tsx
+++ b/src/components/inmuebles/PropertyCard.tsx
@@ -1,3 +1,5 @@
+import Link from "next/link";
+
 import { FALLBACK_IMAGE } from "@/components/FeaturedProperties/useProperties";
 import type { ApiProperty } from "@/components/FeaturedProperties/useProperties";
 import type { ViewMode } from "./FiltersBar";
@@ -40,11 +42,7 @@ const PropertyCard = ({ property, viewMode }: PropertyCardProps) => {
 
   const statusLabel = property.status?.name ?? property.operation ?? "Disponible";
   const operationLabel = property.operation ?? "";
-  const whatsappMessage = encodeURIComponent(
-    `Hola, me interesa la propiedad "${property.title}" (${formattedPrice}).`
-  );
-
-  const whatsappHref = `https://wa.me/?text=${whatsappMessage}`;
+  const propertyHref = `/inmuebles/${property.slug ?? property.id}`;
 
   const isListMode = viewMode === "list";
   const baseArticleClasses =
@@ -113,20 +111,12 @@ const PropertyCard = ({ property, viewMode }: PropertyCardProps) => {
             isListMode ? "md:items-center" : ""
           }`}
         >
-          <a
-            href="#contacto"
+          <Link
+            href={propertyHref}
             className="flex-1 rounded-full bg-[var(--indigo)] px-5 py-3 text-center text-white transition hover:bg-[var(--lime)] hover:text-black"
           >
-            Contactar asesor
-          </a>
-          <a
-            href={whatsappHref}
-            target="_blank"
-            rel="noopener noreferrer"
-            className="flex-1 rounded-full border border-[var(--indigo)] px-5 py-3 text-center text-[var(--indigo)] transition hover:bg-[var(--indigo)] hover:text-white"
-          >
-            Hablar por WhatsApp
-          </a>
+            Ver información
+          </Link>
         </div>
       </div>
     </article>


### PR DESCRIPTION
## Summary
- add the slug field to ApiProperty objects and mapped featured property data
- adjust property cards to link to the property detail page using the slug
- expose the slug on carousel property data for future use

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e1e78158c083238670a64e5faa8b9e