### PR TITLE
Add property detail page with slug helper

### DIFF
--- a/src/app/inmuebles/[slug]/page.tsx
+++ b/src/app/inmuebles/[slug]/page.tsx
@@ -1,0 +1,172 @@
+import type { Metadata } from "next";
+import { notFound } from "next/navigation";
+
+import ContactSection from "@/components/ContactSection";
+import Footer from "@/components/Footer";
+import Navbar from "@/components/Navbar";
+import { prisma } from "@/lib/prisma";
+import { getPropertyBySlug } from "@/lib/properties";
+
+export const revalidate = 60;
+
+type PropertyPageProps = {
+  params: {
+    slug: string;
+  };
+};
+
+const buildOpenGraphImages = (property: any) => {
+  return (property?.imagenes ?? [])
+    .map((image: any) => {
+      const imageMetadata = (image.metadata ?? {}) as { alt?: string };
+      const url = image.url ?? image.path;
+
+      if (!url) {
+        return null;
+      }
+
+      return {
+        url,
+        alt: imageMetadata?.alt ?? property?.titulo ?? "Imagen del inmueble",
+      };
+    })
+    .filter((image: { url: string } | null): image is { url: string; alt?: string } => Boolean(image));
+};
+
+export async function generateStaticParams() {
+  const properties = await prisma.inmueble.findMany({
+    select: { slug: true },
+    where: { slug: { not: null } } as any,
+  } as any);
+
+  return (properties ?? [])
+    .map((property: any) => property?.slug)
+    .filter((slug: string | null | undefined): slug is string => Boolean(slug))
+    .map((slug) => ({ slug }));
+}
+
+export async function generateMetadata({ params }: PropertyPageProps): Promise<Metadata> {
+  const property = await getPropertyBySlug({ slug: params.slug });
+
+  if (!property) {
+    return {
+      title: "Inmueble no encontrado | Villanueva García",
+      description: "La propiedad solicitada no existe o ha sido deshabilitada.",
+    };
+  }
+
+  const locationSegments = [property.colonia, property.municipio, property.estado].filter(Boolean);
+  const locationLabel = locationSegments.join(", ");
+  const baseTitle = property.titulo ?? "Detalle de inmueble";
+  const title = `${baseTitle} | Villanueva García`;
+  const description =
+    property.descripcion ??
+    `Conoce los detalles de ${baseTitle}${locationLabel ? ` ubicada en ${locationLabel}` : ""}.`;
+
+  const images = buildOpenGraphImages(property);
+
+  return {
+    title,
+    description,
+    openGraph: {
+      title,
+      description,
+      type: "article",
+      url: `https://villanuevagarcia.mx/inmuebles/${params.slug}`,
+      images,
+    },
+  };
+}
+
+const PropertyPage = async ({ params }: PropertyPageProps) => {
+  const property = await getPropertyBySlug({ slug: params.slug });
+
+  if (!property) {
+    notFound();
+  }
+
+  const coverImage = property.imagenes?.[0]?.url ?? property.imagenes?.[0]?.path ?? null;
+  const statusName = property.estatus?.nombre ?? "Sin estatus";
+
+  return (
+    <div className="bg-[var(--bg-base)] text-[var(--text-dark)]">
+      <Navbar />
+      <main className="min-h-screen bg-[#f1efeb] pt-20 pb-16 md:pt-28 md:pb-20">
+        <section className="mx-auto max-w-5xl rounded-lg bg-white px-6 py-10 shadow-sm">
+          <div className="space-y-8">
+            <header>
+              <span className="inline-flex items-center rounded-full bg-[var(--accent-light)] px-4 py-1 text-sm font-semibold text-[var(--accent-dark)]">
+                {statusName}
+              </span>
+              <h1 className="mt-4 text-3xl font-bold text-[var(--text-dark)] md:text-4xl">
+                {property.titulo}
+              </h1>
+              <p className="mt-2 text-base text-gray-600">{property.direccion}</p>
+            </header>
+
+            {coverImage ? (
+              <div className="overflow-hidden rounded-lg bg-gray-100">
+                <img
+                  src={coverImage}
+                  alt={property.titulo ?? "Imagen del inmueble"}
+                  className="h-64 w-full object-cover md:h-96"
+                />
+              </div>
+            ) : null}
+
+            {property.descripcion ? (
+              <article className="space-y-4 text-lg leading-relaxed text-gray-700">
+                {property.descripcion.split("\n").map((paragraph: string, index: number) => (
+                  <p key={`paragraph-${index}`}>{paragraph}</p>
+                ))}
+              </article>
+            ) : null}
+
+            <div className="grid gap-8 md:grid-cols-2">
+              <div>
+                <h2 className="text-xl font-semibold text-[var(--text-dark)]">Detalles generales</h2>
+                <ul className="mt-3 space-y-2 text-gray-700">
+                  <li>
+                    <strong>Operación:</strong> {property.operacion ?? "Sin especificar"}
+                  </li>
+                  <li>
+                    <strong>Tipo:</strong> {property.tipo ?? "Sin especificar"}
+                  </li>
+                  <li>
+                    <strong>Precio:</strong> {property.precio ? `$${property.precio}` : "No disponible"}
+                  </li>
+                  <li>
+                    <strong>Actualización:</strong> {property.updatedAt ? new Date(property.updatedAt).toLocaleDateString() : "No disponible"}
+                  </li>
+                </ul>
+              </div>
+              <div>
+                <h2 className="text-xl font-semibold text-[var(--text-dark)]">Ubicación</h2>
+                <ul className="mt-3 space-y-2 text-gray-700">
+                  <li>
+                    <strong>Colonia:</strong> {property.colonia ?? "No especificada"}
+                  </li>
+                  <li>
+                    <strong>Municipio:</strong> {property.municipio ?? "No especificado"}
+                  </li>
+                  <li>
+                    <strong>Estado:</strong> {property.estado ?? "No especificado"}
+                  </li>
+                  <li>
+                    <strong>Código postal:</strong> {property.codigoPostal ?? "No especificado"}
+                  </li>
+                </ul>
+              </div>
+            </div>
+          </div>
+        </section>
+        <div className="mt-12">
+          <ContactSection />
+        </div>
+      </main>
+      <Footer />
+    </div>
+  );
+};
+
+export default PropertyPage;

--- a/src/lib/properties.ts
+++ b/src/lib/properties.ts
@@ -1,0 +1,66 @@
+import { prisma } from "./prisma";
+
+export interface GetPropertyBySlugParams {
+  slug: string;
+  id?: string | number | bigint;
+}
+
+const propertyInclude = {
+  estatus: true,
+  imagenes: {
+    orderBy: [{ orden: "asc" }, { createdAt: "asc" }],
+  },
+} as const;
+
+const normalizeId = (id: string | number | bigint) => {
+  if (typeof id === "bigint") {
+    return id;
+  }
+
+  if (typeof id === "number") {
+    return BigInt(id);
+  }
+
+  return BigInt(id);
+};
+
+const attachMetadata = async <T extends { id: bigint } | null>(property: T) => {
+  if (!property) {
+    return property;
+  }
+
+  const metadataDelegate = (prisma as any).inmuebleMetadata;
+
+  if (metadataDelegate?.findMany) {
+    const metadata = await metadataDelegate.findMany({
+      where: { inmuebleId: property.id } as any,
+      orderBy: { orden: "asc" } as any,
+    });
+
+    return {
+      ...property,
+      metadata,
+    };
+  }
+
+  return property;
+};
+
+export const getPropertyBySlug = async ({ slug, id }: GetPropertyBySlugParams) => {
+  const propertyBySlug = await prisma.inmueble.findUnique({
+    where: { slug } as any,
+    include: propertyInclude,
+  } as any);
+
+  if (propertyBySlug || id === undefined) {
+    return attachMetadata(propertyBySlug as any);
+  }
+
+  const normalizedId = normalizeId(id);
+  const propertyById = await prisma.inmueble.findUnique({
+    where: { id: normalizedId } as any,
+    include: propertyInclude,
+  } as any);
+
+  return attachMetadata(propertyById as any);
+};


### PR DESCRIPTION
## Summary
- add a reusable helper to retrieve inmuebles by slug or id, including status, images, and optional metadata
- create the dynamic inmueble detail page that sets metadata, renders property information, and pre-generates static params

## Testing
- not run (per instructions)


------
https://chatgpt.com/codex/tasks/task_e_68e1e8dc73f48323891c0c09621e43aa