### PR TITLE
feat: enhance property detail page with gallery and map

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,14 +13,17 @@
     "@aws-sdk/s3-request-presigner": "^3.726.1",
     "@prisma/client": "^6.16.3",
     "framer-motion": "^12.23.22",
+    "leaflet": "^1.9.4",
     "lucide-react": "^0.544.0",
     "next": "15.5.4",
     "react": "19.1.0",
     "react-dom": "19.1.0",
+    "react-leaflet": "^5.0.0",
     "swiper": "^11.2.10"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3",
+    "@types/leaflet": "^1.9.12",
     "@tailwindcss/postcss": "^4",
     "@types/node": "^20",
     "@types/react": "^19",

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,4 +1,5 @@
 @import "tailwindcss";
+@import "leaflet/dist/leaflet.css";
 
 html {
   scroll-behavior: smooth;
@@ -114,6 +115,54 @@ body {
   background-attachment: fixed;
   background-size: cover;
   background-position: center;
+}
+
+.leaflet-container {
+  width: 100%;
+  height: 100%;
+  border-radius: 16px;
+  box-shadow: 0 18px 35px rgba(124, 58, 237, 0.12);
+}
+
+.leaflet-control-attribution {
+  font-size: 0.75rem;
+}
+
+.custom-property-marker .marker-shell {
+  position: relative;
+  width: 42px;
+  height: 42px;
+  display: grid;
+  place-items: center;
+}
+
+.custom-property-marker .marker-core {
+  width: 18px;
+  height: 18px;
+  border-radius: 50%;
+  background: linear-gradient(135deg, var(--indigo), var(--lime));
+  border: 4px solid #ffffff;
+  box-shadow: 0 10px 25px rgba(124, 58, 237, 0.35);
+}
+
+.custom-property-marker .marker-pulse {
+  position: absolute;
+  width: 42px;
+  height: 42px;
+  border-radius: 50%;
+  background: rgba(124, 58, 237, 0.22);
+  animation: markerPulse 2.5s ease-in-out infinite;
+}
+
+@keyframes markerPulse {
+  0% {
+    transform: scale(0.5);
+    opacity: 0.75;
+  }
+  100% {
+    transform: scale(1.4);
+    opacity: 0;
+  }
 }
 
 @media (max-width: 768px) {

--- a/src/app/inmuebles/[slug]/page.tsx
+++ b/src/app/inmuebles/[slug]/page.tsx
@@ -4,6 +4,10 @@ import { notFound } from "next/navigation";
 import ContactSection from "@/components/ContactSection";
 import Footer from "@/components/Footer";
 import Navbar from "@/components/Navbar";
+import PropertyGallery from "@/components/inmuebles/PropertyGallery";
+import PropertyHighlights from "@/components/inmuebles/PropertyHighlights";
+import InterestForm from "@/components/inmuebles/InterestForm";
+import PropertyMap from "@/components/inmuebles/PropertyMap";
 import { prisma } from "@/lib/prisma";
 import { getPropertyBySlug } from "@/lib/properties";
 
@@ -85,83 +89,191 @@ const PropertyPage = async ({ params }: PropertyPageProps) => {
     notFound();
   }
 
-  const coverImage = property.imagenes?.[0]?.url ?? property.imagenes?.[0]?.path ?? null;
   const statusName = property.estatus?.nombre ?? "Sin estatus";
+  const images = (property.imagenes ?? [])
+    .map((image) => ({
+      url: image?.url ?? image?.path ?? "",
+      alt: (image?.metadata as { alt?: string } | null)?.alt ?? property.titulo ?? "Imagen del inmueble",
+    }))
+    .filter((image) => Boolean(image.url));
+
+  const price = property.precio
+    ? new Intl.NumberFormat("es-MX", {
+        style: "currency",
+        currency: "MXN",
+        maximumFractionDigits: 0,
+      }).format(Number(property.precio))
+    : "No disponible";
+
+  const updatedAtLabel = property.updatedAt
+    ? new Date(property.updatedAt).toLocaleDateString("es-MX", {
+        year: "numeric",
+        month: "long",
+        day: "numeric",
+      })
+    : null;
+
+  const metrics = [
+    {
+      label: "Recámaras",
+      value: property.habitaciones ? `${property.habitaciones}` : "Por confirmar",
+    },
+    {
+      label: "Baños",
+      value: property.banos ? `${property.banos}` : "Por confirmar",
+    },
+    {
+      label: "Estacionamientos",
+      value: property.estacionamientos ? `${property.estacionamientos}` : "Por confirmar",
+    },
+    {
+      label: "Construcción",
+      value: property.superficie_construida
+        ? `${Number(property.superficie_construida).toLocaleString("es-MX", {
+            minimumFractionDigits: 0,
+            maximumFractionDigits: 0,
+          })} m²`
+        : "Por confirmar",
+    },
+    {
+      label: "Terreno",
+      value: property.superficie_terreno
+        ? `${Number(property.superficie_terreno).toLocaleString("es-MX", {
+            minimumFractionDigits: 0,
+            maximumFractionDigits: 0,
+          })} m²`
+        : "Por confirmar",
+    },
+    {
+      label: "Año de construcción",
+      value: property.anio_construccion ? `${property.anio_construccion}` : "Por confirmar",
+    },
+  ].filter((metric) => metric.value);
+
+  const parseList = (value?: string | null) => {
+    if (!value) {
+      return [] as string[];
+    }
+
+    return value
+      .split(/\r?\n|,|\u2022|;|\|/)
+      .map((item) => item.replace(/^[-•\s]+/, "").trim())
+      .filter(Boolean);
+  };
+
+  const amenities = parseList(property.amenidades);
+  const extras = parseList(property.extras);
+  const descriptionParagraphs = property.descripcion
+    ? property.descripcion.split("\n").map((paragraph) => paragraph.trim()).filter(Boolean)
+    : [];
+
+  const locationSegments = [property.colonia, property.municipio, property.estado].filter(Boolean);
+  const locationLabel = locationSegments.join(", ");
+
+  const latitude = property.latitud ? Number(property.latitud) : null;
+  const longitude = property.longitud ? Number(property.longitud) : null;
 
   return (
     <div className="bg-[var(--bg-base)] text-[var(--text-dark)]">
       <Navbar />
-      <main className="min-h-screen bg-[#f1efeb] pt-20 pb-16 md:pt-28 md:pb-20">
-        <section className="mx-auto max-w-5xl rounded-lg bg-white px-6 py-10 shadow-sm">
-          <div className="space-y-8">
-            <header>
-              <span className="inline-flex items-center rounded-full bg-[var(--accent-light)] px-4 py-1 text-sm font-semibold text-[var(--accent-dark)]">
+      <main className="min-h-screen bg-[#f1efeb] pt-24 pb-20 md:pt-32 md:pb-24">
+        <div className="mx-auto flex max-w-6xl flex-col gap-12 px-4 sm:px-6 lg:px-8">
+          <header className="flex flex-col gap-6 rounded-3xl border border-white/60 bg-white/80 p-8 shadow-lg backdrop-blur">
+            <div className="flex flex-wrap items-center gap-4">
+              <span className="inline-flex items-center rounded-full bg-[var(--indigo)]/10 px-4 py-1 text-xs font-semibold uppercase tracking-[0.3em] text-[var(--indigo)]">
                 {statusName}
               </span>
-              <h1 className="mt-4 text-3xl font-bold text-[var(--text-dark)] md:text-4xl">
+              {locationLabel ? (
+                <span className="inline-flex items-center rounded-full border border-[var(--indigo)]/20 bg-white px-4 py-1 text-xs font-medium text-[var(--text-dark)]">
+                  {locationLabel}
+                </span>
+              ) : null}
+            </div>
+            <div className="space-y-3">
+              <h1 className="text-3xl font-bold text-[var(--text-dark)] sm:text-4xl md:text-5xl">
                 {property.titulo}
               </h1>
-              <p className="mt-2 text-base text-gray-600">{property.direccion}</p>
-            </header>
-
-            {coverImage ? (
-              <div className="overflow-hidden rounded-lg bg-gray-100">
-                <img
-                  src={coverImage}
-                  alt={property.titulo ?? "Imagen del inmueble"}
-                  className="h-64 w-full object-cover md:h-96"
-                />
-              </div>
-            ) : null}
-
-            {property.descripcion ? (
-              <article className="space-y-4 text-lg leading-relaxed text-gray-700">
-                {property.descripcion.split("\n").map((paragraph: string, index: number) => (
-                  <p key={`paragraph-${index}`}>{paragraph}</p>
-                ))}
-              </article>
-            ) : null}
-
-            <div className="grid gap-8 md:grid-cols-2">
-              <div>
-                <h2 className="text-xl font-semibold text-[var(--text-dark)]">Detalles generales</h2>
-                <ul className="mt-3 space-y-2 text-gray-700">
-                  <li>
-                    <strong>Operación:</strong> {property.operacion ?? "Sin especificar"}
-                  </li>
-                  <li>
-                    <strong>Tipo:</strong> {property.tipo ?? "Sin especificar"}
-                  </li>
-                  <li>
-                    <strong>Precio:</strong> {property.precio ? `$${property.precio}` : "No disponible"}
-                  </li>
-                  <li>
-                    <strong>Actualización:</strong> {property.updatedAt ? new Date(property.updatedAt).toLocaleDateString() : "No disponible"}
-                  </li>
-                </ul>
-              </div>
-              <div>
-                <h2 className="text-xl font-semibold text-[var(--text-dark)]">Ubicación</h2>
-                <ul className="mt-3 space-y-2 text-gray-700">
-                  <li>
-                    <strong>Colonia:</strong> {property.colonia ?? "No especificada"}
-                  </li>
-                  <li>
-                    <strong>Municipio:</strong> {property.municipio ?? "No especificado"}
-                  </li>
-                  <li>
-                    <strong>Estado:</strong> {property.estado ?? "No especificado"}
-                  </li>
-                  <li>
-                    <strong>Código postal:</strong> {property.codigoPostal ?? "No especificado"}
-                  </li>
-                </ul>
-              </div>
+              <p className="text-base text-gray-600">{property.direccion}</p>
             </div>
+          </header>
+
+          <PropertyGallery images={images} title={property.titulo} />
+
+          <PropertyHighlights
+            price={price}
+            operation={property.operacion}
+            type={property.tipo}
+            status={statusName}
+            updatedAt={updatedAtLabel}
+            metrics={metrics}
+            amenities={amenities}
+          />
+
+          <section className="grid gap-10 lg:grid-cols-[2fr,1fr]">
+            <article className="space-y-8 rounded-3xl border border-white/60 bg-white/80 p-8 shadow-lg backdrop-blur">
+              {descriptionParagraphs.length ? (
+                <div className="space-y-4">
+                  <h2 className="text-2xl font-semibold text-[var(--text-dark)]">Descripción</h2>
+                  <div className="space-y-4 text-base leading-relaxed text-gray-700">
+                    {descriptionParagraphs.map((paragraph, index) => (
+                      <p key={`description-${index}`}>{paragraph}</p>
+                    ))}
+                  </div>
+                </div>
+              ) : null}
+
+              <div className="grid gap-6 md:grid-cols-2">
+                <div className="space-y-4">
+                  <h3 className="text-lg font-semibold text-[var(--text-dark)]">Ubicación detallada</h3>
+                  <ul className="space-y-2 text-sm text-gray-600">
+                    <li><strong>Colonia:</strong> {property.colonia ?? "No especificada"}</li>
+                    <li><strong>Municipio:</strong> {property.municipio ?? "No especificado"}</li>
+                    <li><strong>Estado:</strong> {property.estado ?? "No especificado"}</li>
+                    <li><strong>Código postal:</strong> {property.codigoPostal ?? "No especificado"}</li>
+                  </ul>
+                </div>
+                {extras.length ? (
+                  <div className="space-y-4">
+                    <h3 className="text-lg font-semibold text-[var(--text-dark)]">Detalles adicionales</h3>
+                    <ul className="grid gap-2 text-sm text-gray-600">
+                      {extras.map((extra) => (
+                        <li key={extra} className="rounded-2xl bg-white/90 px-4 py-2 shadow-sm">
+                          {extra}
+                        </li>
+                      ))}
+                    </ul>
+                  </div>
+                ) : null}
+              </div>
+
+              {amenities.length ? (
+                <div className="space-y-4">
+                  <h3 className="text-lg font-semibold text-[var(--text-dark)]">Amenidades completas</h3>
+                  <ul className="grid gap-3 sm:grid-cols-2">
+                    {amenities.map((amenity) => (
+                      <li key={amenity} className="flex items-center gap-3 rounded-2xl bg-white/90 px-4 py-3 text-sm font-medium text-gray-700 shadow-sm">
+                        <span className="inline-flex h-2 w-2 rounded-full bg-[var(--lime)]" />
+                        {amenity}
+                      </li>
+                    ))}
+                  </ul>
+                </div>
+              ) : null}
+            </article>
+
+            <InterestForm propertyTitle={property.titulo} />
+          </section>
+
+          <PropertyMap
+            latitude={latitude}
+            longitude={longitude}
+            title={property.titulo}
+            address={property.direccion}
+          />
+
+          <div className="mt-4">
+            <ContactSection />
           </div>
-        </section>
-        <div className="mt-12">
-          <ContactSection />
         </div>
       </main>
       <Footer />

--- a/src/components/inmuebles/InterestForm.tsx
+++ b/src/components/inmuebles/InterestForm.tsx
@@ -1,0 +1,165 @@
+"use client";
+
+import { ChangeEvent, FormEvent, useMemo, useState } from "react";
+import { motion } from "framer-motion";
+import { PhoneCall, Send } from "lucide-react";
+
+type InterestFormProps = {
+  propertyTitle?: string | null;
+};
+
+type FormDataState = {
+  name: string;
+  email: string;
+  phone: string;
+  message: string;
+};
+
+const defaultState: FormDataState = {
+  name: "",
+  email: "",
+  phone: "",
+  message: "",
+};
+
+const phoneNumber = "5584438656";
+
+const InterestForm = ({ propertyTitle }: InterestFormProps) => {
+  const [formData, setFormData] = useState<FormDataState>(defaultState);
+  const [error, setError] = useState<string | null>(null);
+  const [feedback, setFeedback] = useState<string | null>(null);
+
+  const isComplete = useMemo(() => {
+    return Object.values(formData).every((value) => value.trim().length > 0);
+  }, [formData]);
+
+  const handleChange = (field: keyof FormDataState) => (event: ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
+    setFormData((prev) => ({ ...prev, [field]: event.target.value }));
+    setError(null);
+    setFeedback(null);
+  };
+
+  const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    if (!isComplete) {
+      setError("Completa todos los campos para que nuestro equipo pueda contactarte.");
+      return;
+    }
+
+    setFeedback("¡Gracias! Hemos recibido tu interés. Muy pronto un asesor se pondrá en contacto contigo.");
+  };
+
+  const handleCallClick = () => {
+    if (!isComplete) {
+      setError("Por favor llena tus datos antes de llamar. Así podremos brindarte un mejor seguimiento.");
+      return;
+    }
+
+    window.location.href = `tel:${phoneNumber}`;
+  };
+
+  return (
+    <motion.section
+      className="rounded-3xl border border-white/60 bg-white/80 p-8 shadow-xl backdrop-blur"
+      initial={{ opacity: 0, y: 40 }}
+      whileInView={{ opacity: 1, y: 0 }}
+      viewport={{ once: true, amount: 0.3 }}
+      transition={{ duration: 0.6 }}
+    >
+      <header className="space-y-2">
+        <h3 className="text-2xl font-semibold text-[var(--text-dark)]">¿Te interesa esta propiedad?</h3>
+        <p className="text-sm text-gray-600">
+          Déjanos tus datos y un asesor de Villanueva García te contactará para brindarte asesoría personalizada.
+        </p>
+      </header>
+
+      <form className="mt-6 space-y-4" onSubmit={handleSubmit} noValidate>
+        <div className="grid gap-4 sm:grid-cols-2">
+          <label className="flex flex-col gap-2 text-sm font-medium text-[var(--text-dark)]">
+            Nombre completo
+            <input
+              type="text"
+              name="name"
+              value={formData.name}
+              onChange={handleChange("name")}
+              className="rounded-2xl border border-gray-200 bg-white/90 px-4 py-3 text-sm shadow-sm outline-none transition focus:border-[var(--indigo)] focus:ring-2 focus:ring-[var(--indigo)]/20"
+              placeholder="¿Cómo te llamas?"
+              required
+            />
+          </label>
+          <label className="flex flex-col gap-2 text-sm font-medium text-[var(--text-dark)]">
+            Correo electrónico
+            <input
+              type="email"
+              name="email"
+              value={formData.email}
+              onChange={handleChange("email")}
+              className="rounded-2xl border border-gray-200 bg-white/90 px-4 py-3 text-sm shadow-sm outline-none transition focus:border-[var(--indigo)] focus:ring-2 focus:ring-[var(--indigo)]/20"
+              placeholder="correo@ejemplo.com"
+              required
+            />
+          </label>
+        </div>
+        <div className="grid gap-4 sm:grid-cols-2">
+          <label className="flex flex-col gap-2 text-sm font-medium text-[var(--text-dark)]">
+            Teléfono
+            <input
+              type="tel"
+              name="phone"
+              value={formData.phone}
+              onChange={handleChange("phone")}
+              className="rounded-2xl border border-gray-200 bg-white/90 px-4 py-3 text-sm shadow-sm outline-none transition focus:border-[var(--indigo)] focus:ring-2 focus:ring-[var(--indigo)]/20"
+              placeholder="10 dígitos"
+              required
+            />
+          </label>
+          <label className="flex flex-col gap-2 text-sm font-medium text-[var(--text-dark)]">
+            Propiedad de interés
+            <input
+              type="text"
+              name="property"
+              value={propertyTitle ?? ""}
+              readOnly
+              className="cursor-not-allowed rounded-2xl border border-gray-200 bg-gray-100 px-4 py-3 text-sm text-gray-500 shadow-inner"
+            />
+          </label>
+        </div>
+        <label className="flex flex-col gap-2 text-sm font-medium text-[var(--text-dark)]">
+          Mensaje
+          <textarea
+            name="message"
+            value={formData.message}
+            onChange={handleChange("message")}
+            rows={4}
+            className="rounded-2xl border border-gray-200 bg-white/90 px-4 py-3 text-sm shadow-sm outline-none transition focus:border-[var(--indigo)] focus:ring-2 focus:ring-[var(--indigo)]/20"
+            placeholder="Cuéntanos qué te gustaría saber"
+            required
+          />
+        </label>
+
+        {error ? <p className="text-sm font-medium text-rose-500">{error}</p> : null}
+        {feedback ? <p className="text-sm font-medium text-emerald-600">{feedback}</p> : null}
+
+        <div className="flex flex-col gap-3 sm:flex-row sm:items-center">
+          <button
+            type="submit"
+            className="inline-flex items-center justify-center gap-2 rounded-full bg-[var(--indigo)] px-6 py-3 text-sm font-semibold text-white shadow-lg transition hover:-translate-y-0.5 hover:shadow-xl focus:outline-none focus:ring-2 focus:ring-[var(--indigo)]/30"
+          >
+            <Send className="h-4 w-4" />
+            Enviar interés
+          </button>
+          <button
+            type="button"
+            onClick={handleCallClick}
+            className="inline-flex items-center justify-center gap-2 rounded-full border border-[var(--indigo)]/60 bg-white px-6 py-3 text-sm font-semibold text-[var(--indigo)] shadow-sm transition hover:-translate-y-0.5 hover:border-[var(--indigo)] focus:outline-none focus:ring-2 focus:ring-[var(--indigo)]/20"
+          >
+            <PhoneCall className="h-4 w-4" />
+            Llamar a la inmobiliaria
+          </button>
+        </div>
+      </form>
+    </motion.section>
+  );
+};
+
+export default InterestForm;

--- a/src/components/inmuebles/PropertyGallery.tsx
+++ b/src/components/inmuebles/PropertyGallery.tsx
@@ -1,0 +1,107 @@
+"use client";
+
+import { useMemo } from "react";
+import { motion } from "framer-motion";
+import { Navigation, Pagination, Autoplay, EffectCreative } from "swiper/modules";
+import { Swiper, SwiperSlide } from "swiper/react";
+import "swiper/css";
+import "swiper/css/navigation";
+import "swiper/css/pagination";
+import "swiper/css/effect-creative";
+
+type GalleryImage = {
+  url: string;
+  alt?: string | null;
+};
+
+type PropertyGalleryProps = {
+  images?: GalleryImage[] | null;
+  title?: string | null;
+};
+
+const shimmerBackground =
+  "linear-gradient(120deg, rgba(124,58,237,0.25), rgba(210,255,30,0.35), rgba(124,58,237,0.25))";
+
+const PropertyGallery = ({ images, title }: PropertyGalleryProps) => {
+  const galleryItems = useMemo(() => {
+    return (images ?? [])
+      .map((image) => ({
+        url: image?.url ?? "",
+        alt: image?.alt ?? title ?? "Imagen del inmueble",
+      }))
+      .filter((image) => Boolean(image.url));
+  }, [images, title]);
+
+  if (!galleryItems.length) {
+    return (
+      <motion.div
+        className="flex h-80 w-full items-center justify-center rounded-3xl border border-[var(--indigo)]/10 bg-gradient-to-br from-[var(--indigo)]/10 via-white to-[var(--lime)]/20 text-center shadow-lg"
+        initial={{ opacity: 0, y: 24 }}
+        animate={{ opacity: 1, y: 0 }}
+        transition={{ duration: 0.6 }}
+      >
+        <div className="space-y-3 px-10">
+          <h2 className="text-2xl font-semibold text-[var(--text-dark)]">Explora cada rincón</h2>
+          <p className="text-base text-gray-600">
+            Muy pronto tendremos fotografías de esta propiedad. Mientras tanto, solicita más información y te
+            compartimos todo el material disponible.
+          </p>
+        </div>
+      </motion.div>
+    );
+  }
+
+  return (
+    <motion.section
+      className="overflow-hidden rounded-3xl border border-white/40 bg-white/80 p-2 shadow-xl backdrop-blur"
+      initial={{ opacity: 0, y: 32 }}
+      animate={{ opacity: 1, y: 0 }}
+      transition={{ duration: 0.6, ease: "easeOut" }}
+    >
+      <Swiper
+        modules={[Navigation, Pagination, Autoplay, EffectCreative]}
+        slidesPerView={1}
+        spaceBetween={24}
+        autoplay={{ delay: 5000, disableOnInteraction: false }}
+        navigation
+        pagination={{ clickable: true }}
+        effect="creative"
+        creativeEffect={{
+          prev: {
+            shadow: true,
+            translate: ["-20%", 0, -1],
+            rotate: [0, 0, -5],
+          },
+          next: {
+            translate: ["100%", 0, 0],
+          },
+        }}
+        className="property-gallery"
+      >
+        {galleryItems.map((image, index) => (
+          <SwiperSlide key={`${image.url}-${index}`}>
+            <motion.figure
+              className="relative h-[420px] w-full overflow-hidden rounded-[26px]"
+              whileHover={{ scale: 0.99 }}
+            >
+              <img
+                src={image.url}
+                alt={image.alt ?? title ?? "Imagen del inmueble"}
+                className="h-full w-full object-cover"
+                style={{ background: shimmerBackground }}
+              />
+              <motion.figcaption
+                className="pointer-events-none absolute inset-0 bg-gradient-to-t from-black/55 via-black/0 to-black/10"
+                initial={{ opacity: 0 }}
+                animate={{ opacity: 1 }}
+                transition={{ delay: 0.2, duration: 0.5 }}
+              />
+            </motion.figure>
+          </SwiperSlide>
+        ))}
+      </Swiper>
+    </motion.section>
+  );
+};
+
+export default PropertyGallery;

--- a/src/components/inmuebles/PropertyHighlights.tsx
+++ b/src/components/inmuebles/PropertyHighlights.tsx
@@ -1,0 +1,142 @@
+"use client";
+
+import { motion } from "framer-motion";
+import { BadgeCheck, Building2, Home, Tag } from "lucide-react";
+
+const highlightVariants = {
+  hidden: { opacity: 0, y: 24 },
+  visible: { opacity: 1, y: 0 },
+};
+
+type Metric = {
+  label: string;
+  value: string;
+};
+
+type PropertyHighlightsProps = {
+  price: string;
+  operation?: string | null;
+  type?: string | null;
+  status?: string | null;
+  updatedAt?: string | null;
+  metrics?: Metric[];
+  amenities?: string[];
+};
+
+const PropertyHighlights = ({
+  price,
+  operation,
+  type,
+  status,
+  updatedAt,
+  metrics = [],
+  amenities = [],
+}: PropertyHighlightsProps) => {
+  const highlightCards = [
+    {
+      icon: Tag,
+      label: "Precio",
+      value: price,
+      accent: true,
+    },
+    {
+      icon: Building2,
+      label: "Operación",
+      value: operation ?? "Sin definir",
+    },
+    {
+      icon: Home,
+      label: "Tipo",
+      value: type ?? "Sin definir",
+    },
+    {
+      icon: BadgeCheck,
+      label: "Estatus",
+      value: status ?? "En revisión",
+    },
+  ];
+
+  const topAmenities = amenities.slice(0, 6);
+
+  return (
+    <section className="space-y-10">
+      <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-4">
+        {highlightCards.map(({ icon: Icon, label, value, accent }, index) => (
+          <motion.article
+            key={label}
+            className={`group relative overflow-hidden rounded-3xl border border-white/60 bg-white/80 p-6 shadow-lg transition-colors duration-300 backdrop-blur ${
+              accent ? "text-[var(--text-dark)]" : "text-gray-700"
+            }`}
+            variants={highlightVariants}
+            initial="hidden"
+            animate="visible"
+            transition={{ duration: 0.4, delay: index * 0.1 }}
+          >
+            <div className="absolute inset-0 bg-gradient-to-br from-[var(--indigo)]/12 via-white/30 to-[var(--lime)]/18 opacity-0 transition-opacity duration-300 group-hover:opacity-100" />
+            <div className="relative z-10 space-y-3">
+              <span className="inline-flex items-center justify-center rounded-full bg-[var(--indigo)]/10 p-3 text-[var(--indigo)]">
+                <Icon className="h-5 w-5" />
+              </span>
+              <div>
+                <p className="text-sm uppercase tracking-[0.14em] text-gray-500">{label}</p>
+                <p className={`text-xl font-semibold md:text-2xl ${accent ? "text-[var(--text-dark)]" : "text-gray-700"}`}>
+                  {value}
+                </p>
+                {label === "Precio" && updatedAt ? (
+                  <span className="mt-1 block text-xs font-medium text-gray-500">
+                    Actualizado el {updatedAt}
+                  </span>
+                ) : null}
+              </div>
+            </div>
+          </motion.article>
+        ))}
+      </div>
+
+      {metrics.length ? (
+        <div className="grid gap-4 rounded-3xl border border-white/50 bg-white/70 p-6 shadow-lg backdrop-blur md:grid-cols-2 lg:grid-cols-4">
+          {metrics.map((metric, index) => (
+            <motion.div
+              key={metric.label}
+              className="flex flex-col rounded-2xl bg-white/80 px-4 py-5 text-center shadow-sm transition hover:-translate-y-1 hover:shadow-md"
+              variants={highlightVariants}
+              initial="hidden"
+              whileInView="visible"
+              viewport={{ once: true, amount: 0.3 }}
+              transition={{ duration: 0.4, delay: index * 0.08 }}
+            >
+              <span className="text-sm font-medium uppercase tracking-wide text-[var(--indigo)]/70">{metric.label}</span>
+              <span className="mt-2 text-2xl font-semibold text-[var(--text-dark)]">{metric.value}</span>
+            </motion.div>
+          ))}
+        </div>
+      ) : null}
+
+      {topAmenities.length ? (
+        <motion.div
+          className="rounded-3xl border border-white/50 bg-white/70 p-8 shadow-lg backdrop-blur"
+          initial="hidden"
+          whileInView="visible"
+          viewport={{ once: true, amount: 0.3 }}
+          variants={highlightVariants}
+          transition={{ duration: 0.5 }}
+        >
+          <h3 className="text-xl font-semibold text-[var(--text-dark)]">Amenidades destacadas</h3>
+          <ul className="mt-4 grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
+            {topAmenities.map((amenity) => (
+              <li
+                key={amenity}
+                className="flex items-center gap-3 rounded-2xl bg-white/80 px-4 py-3 text-sm font-medium text-gray-700 shadow-sm"
+              >
+                <span className="inline-flex h-2 w-2 rounded-full bg-[var(--indigo)]" />
+                {amenity}
+              </li>
+            ))}
+          </ul>
+        </motion.div>
+      ) : null}
+    </section>
+  );
+};
+
+export default PropertyHighlights;

--- a/src/components/inmuebles/PropertyMap.tsx
+++ b/src/components/inmuebles/PropertyMap.tsx
@@ -1,0 +1,86 @@
+"use client";
+
+import { useMemo } from "react";
+import { MapContainer, Marker, Popup, TileLayer } from "react-leaflet";
+import L from "leaflet";
+
+type PropertyMapProps = {
+  latitude?: number | null;
+  longitude?: number | null;
+  title?: string | null;
+  address?: string | null;
+};
+
+const PropertyMap = ({ latitude, longitude, title, address }: PropertyMapProps) => {
+  const numericLatitude = typeof latitude === "number" ? latitude : latitude ? Number(latitude) : null;
+  const numericLongitude = typeof longitude === "number" ? longitude : longitude ? Number(longitude) : null;
+
+  const position = useMemo(() => {
+    if (typeof numericLatitude !== "number" || typeof numericLongitude !== "number") {
+      return null;
+    }
+
+    if (Number.isNaN(numericLatitude) || Number.isNaN(numericLongitude)) {
+      return null;
+    }
+
+    return [numericLatitude, numericLongitude] as [number, number];
+  }, [numericLatitude, numericLongitude]);
+
+  const markerIcon = useMemo(
+    () =>
+      L.divIcon({
+        className: "custom-property-marker",
+        html: `
+          <div class="marker-shell">
+            <span class="marker-pulse"></span>
+            <span class="marker-core"></span>
+          </div>
+        `,
+        iconSize: [46, 60],
+        iconAnchor: [23, 58],
+        popupAnchor: [0, -54],
+      }),
+    []
+  );
+
+  if (!position) {
+    return (
+      <div className="flex h-80 w-full flex-col items-center justify-center gap-3 rounded-3xl border border-dashed border-[var(--indigo)]/30 bg-white/70 text-center text-gray-600">
+        <p className="text-lg font-semibold text-[var(--text-dark)]">Mapa no disponible</p>
+        <p className="max-w-md text-sm text-gray-500">
+          En cuanto recibamos las coordenadas de este inmueble, podrás explorar la zona y calcular rutas fácilmente.
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="relative overflow-hidden rounded-3xl border border-white/60 bg-white/80 shadow-xl backdrop-blur">
+      <div className="absolute left-6 top-6 z-20 rounded-full bg-white/90 px-4 py-2 text-xs font-semibold uppercase tracking-[0.2em] text-[var(--indigo)]">
+        Ubicación
+      </div>
+      <MapContainer
+        center={position}
+        zoom={16}
+        scrollWheelZoom={false}
+        style={{ height: "420px", width: "100%" }}
+      >
+        <TileLayer
+          attribution='&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors'
+          url="https://{s}.tile.openstreetmap.fr/hot/{z}/{x}/{y}.png"
+        />
+        <Marker position={position} icon={markerIcon}>
+          <Popup>
+            <div className="space-y-1">
+              <p className="text-sm font-semibold text-[var(--text-dark)]">{title}</p>
+              {address ? <p className="text-xs text-gray-600">{address}</p> : null}
+            </div>
+          </Popup>
+        </Marker>
+      </MapContainer>
+    </div>
+  );
+};
+
+export default PropertyMap;


### PR DESCRIPTION
## Summary
- add Leaflet and React Leaflet dependencies and register global map styles
- create reusable property detail components for gallery, highlights, map, and interest form
- redesign the property detail page to use the new components with richer data presentation

## Testing
- not run (per instructions)


------
https://chatgpt.com/codex/tasks/task_e_68e1ea5cdac48323a5cb47a09e454571