### PR TITLE
Add slug fallback for properties API

### DIFF
--- a/src/components/inmuebles/PropertyCard.tsx
+++ b/src/components/inmuebles/PropertyCard.tsx
@@ -42,7 +42,7 @@ const PropertyCard = ({ property, viewMode }: PropertyCardProps) => {
 
   const statusLabel = property.status?.name ?? property.operation ?? "Disponible";
   const operationLabel = property.operation ?? "";
-  const propertyHref = `/inmuebles/${property.slug ?? property.id}`;
+  const propertyHref = `/inmuebles/${property.slug}`;
 
   const isListMode = viewMode === "list";
   const baseArticleClasses =


### PR DESCRIPTION
## Summary
- normalize property titles to create slug fallbacks in the properties API
- rely on the generated slug when linking to property detail pages

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e1f2827be483239d992c1cd1b3a028