### PR TITLE
Add slug column to Inmueble and backfill support

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "dev": "next dev --turbopack",
     "build": "next build --turbopack",
     "start": "next start",
-    "lint": "eslint"
+    "lint": "eslint",
+    "backfill:inmueble-slug": "node scripts/backfill-inmueble-slug.js"
   },
   "dependencies": {
     "@aws-sdk/client-s3": "^3.726.1",

--- a/prisma/migrations/20241009120000_add-inmueble-slug/migration.sql
+++ b/prisma/migrations/20241009120000_add-inmueble-slug/migration.sql
@@ -1,0 +1,80 @@
+ALTER TABLE `inmuebles`
+  ADD COLUMN `slug` VARCHAR(200) NULL;
+
+UPDATE `inmuebles`
+SET `slug` = CASE
+  WHEN `slug` IS NOT NULL AND TRIM(`slug`) <> '' THEN TRIM(`slug`)
+  WHEN `titulo` IS NULL OR TRIM(`titulo`) = '' THEN CAST(`id` AS CHAR(191))
+  ELSE
+    LEFT(
+      REGEXP_REPLACE(
+        REGEXP_REPLACE(
+          LOWER(
+            REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(
+              TRIM(`titulo`),
+              'Á', 'A'),
+              'À', 'A'),
+              'Â', 'A'),
+              'Ä', 'A'),
+              'Ã', 'A'),
+              'Å', 'A'),
+              'á', 'a'),
+              'à', 'a'),
+              'â', 'a'),
+              'ä', 'a'),
+              'ã', 'a'),
+              'å', 'a'),
+              'É', 'E'),
+              'È', 'E'),
+              'Ê', 'E'),
+              'Ë', 'E'),
+              'é', 'e'),
+              'è', 'e'),
+              'ê', 'e'),
+              'ë', 'e'),
+              'Í', 'I'),
+              'Ì', 'I'),
+              'Î', 'I'),
+              'Ï', 'I'),
+              'í', 'i'),
+              'ì', 'i'),
+              'î', 'i'),
+              'ï', 'i'),
+              'Ó', 'O'),
+              'Ò', 'O'),
+              'Ô', 'O'),
+              'Ö', 'O'),
+              'Õ', 'O'),
+              'Ø', 'O'),
+              'ó', 'o'),
+              'ò', 'o'),
+              'ô', 'o'),
+              'ö', 'o'),
+              'õ', 'o'),
+              'ø', 'o'),
+              'Ú', 'U'),
+              'Ù', 'U'),
+              'Û', 'U'),
+              'Ü', 'U'),
+              'ú', 'u'),
+              'ù', 'u'),
+              'û', 'u'),
+              'ü', 'u'),
+              'Ñ', 'N'),
+              'ñ', 'n'),
+              'Ç', 'C'),
+              'ç', 'c'),
+              'Ý', 'Y'),
+              'ý', 'y'),
+              'ÿ', 'y')
+          ),
+          '[^a-z0-9]+', '-'
+        ),
+        '(^-+)|(-+$)', ''
+      ),
+      200
+    )
+END
+WHERE `slug` IS NULL OR TRIM(`slug`) = '';
+
+CREATE UNIQUE INDEX `inmuebles_slug_key` ON `inmuebles`(`slug`);

--- a/prisma/migrations/migration_lock.toml
+++ b/prisma/migrations/migration_lock.toml
@@ -1,0 +1,1 @@
+provider = "mysql"

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -21,6 +21,7 @@ model Inmueble {
   descripcion           String?             @db.Text
   precio                Decimal             @db.Decimal(12, 2)
   direccion             String              @db.VarChar(255)
+  slug                  String?             @unique @db.VarChar(200)
   latitud               Decimal?            @db.Decimal(10, 6)
   longitud              Decimal?            @db.Decimal(10, 6)
   colonia               String?             @db.VarChar(255)

--- a/scripts/backfill-inmueble-slug.js
+++ b/scripts/backfill-inmueble-slug.js
@@ -1,0 +1,81 @@
+#!/usr/bin/env node
+const { PrismaClient } = require("@prisma/client");
+
+const prisma = new PrismaClient();
+
+const normalizeSlug = (value) => {
+  if (!value) {
+    return "";
+  }
+
+  return value
+    .normalize("NFD")
+    .replace(/\p{Diacritic}/gu, "")
+    .toLowerCase()
+    .trim()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+};
+
+const buildSlug = (inmueble, usedSlugs) => {
+  const baseSlug = normalizeSlug(inmueble.titulo);
+  const fallback = inmueble.id.toString();
+  const initialSlug = baseSlug || fallback;
+
+  if (!usedSlugs.has(initialSlug)) {
+    usedSlugs.add(initialSlug);
+    return initialSlug;
+  }
+
+  let candidate = `${initialSlug}-${inmueble.id}`;
+  let counter = 1;
+
+  while (usedSlugs.has(candidate)) {
+    counter += 1;
+    candidate = `${initialSlug}-${inmueble.id}-${counter}`;
+  }
+
+  usedSlugs.add(candidate);
+  return candidate;
+};
+
+async function main() {
+  const inmuebles = await prisma.inmueble.findMany({
+    select: { id: true, titulo: true, slug: true },
+    orderBy: { id: "asc" },
+  });
+
+  const usedSlugs = new Set(
+    inmuebles
+      .map((item) => item.slug?.trim())
+      .filter((slug) => typeof slug === "string" && slug.length > 0),
+  );
+
+  const updates = inmuebles
+    .map((inmueble) => {
+      const nextSlug = buildSlug(inmueble, usedSlugs);
+
+      if (inmueble.slug === nextSlug) {
+        return null;
+      }
+
+      return prisma.inmueble.update({
+        where: { id: inmueble.id },
+        data: { slug: nextSlug },
+      });
+    })
+    .filter(Boolean);
+
+  for (const update of updates) {
+    await update;
+  }
+}
+
+main()
+  .catch((error) => {
+    console.error("Failed to backfill inmueble slugs", error);
+    process.exit(1);
+  })
+  .finally(async () => {
+    await prisma.$disconnect();
+  });


### PR DESCRIPTION
## Summary
- add an optional unique `slug` field to the `Inmueble` Prisma model and include a migration to populate existing records
- provide a reusable script and npm task to backfill consistent slugs based on the `normalizeSlug` logic

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e1f642bdfc8323b62b4737ea67a888