### PR TITLE
Update backfill script to use existing slugs

### DIFF
--- a/scripts/backfill-inmueble-slug.js
+++ b/scripts/backfill-inmueble-slug.js
@@ -3,65 +3,23 @@ const { PrismaClient } = require("@prisma/client");
 
 const prisma = new PrismaClient();
 
-const normalizeSlug = (value) => {
-  if (!value) {
-    return "";
-  }
-
-  return value
-    .normalize("NFD")
-    .replace(/\p{Diacritic}/gu, "")
-    .toLowerCase()
-    .trim()
-    .replace(/[^a-z0-9]+/g, "-")
-    .replace(/^-+|-+$/g, "");
-};
-
-const buildSlug = (inmueble, usedSlugs) => {
-  const baseSlug = normalizeSlug(inmueble.titulo);
-  const fallback = inmueble.id.toString();
-  const initialSlug = baseSlug || fallback;
-
-  if (!usedSlugs.has(initialSlug)) {
-    usedSlugs.add(initialSlug);
-    return initialSlug;
-  }
-
-  let candidate = `${initialSlug}-${inmueble.id}`;
-  let counter = 1;
-
-  while (usedSlugs.has(candidate)) {
-    counter += 1;
-    candidate = `${initialSlug}-${inmueble.id}-${counter}`;
-  }
-
-  usedSlugs.add(candidate);
-  return candidate;
-};
-
 async function main() {
   const inmuebles = await prisma.inmueble.findMany({
     select: { id: true, titulo: true, slug: true },
     orderBy: { id: "asc" },
   });
 
-  const usedSlugs = new Set(
-    inmuebles
-      .map((item) => item.slug?.trim())
-      .filter((slug) => typeof slug === "string" && slug.length > 0),
-  );
-
   const updates = inmuebles
     .map((inmueble) => {
-      const nextSlug = buildSlug(inmueble, usedSlugs);
+      const currentSlug = inmueble.slug?.trim();
 
-      if (inmueble.slug === nextSlug) {
+      if (!currentSlug || currentSlug === inmueble.slug) {
         return null;
       }
 
       return prisma.inmueble.update({
         where: { id: inmueble.id },
-        data: { slug: nextSlug },
+        data: { slug: currentSlug },
       });
     })
     .filter(Boolean);


### PR DESCRIPTION
## Summary
- remove slug normalization logic and the used slug tracking
- rely on existing inmueble slugs, trimming them when necessary before updating

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e1fd696cd88323ac367fd69aa1cadc