### PR TITLE
Handle promise-based params on property page

### DIFF
--- a/src/app/inmuebles/[slug]/page.tsx
+++ b/src/app/inmuebles/[slug]/page.tsx
@@ -14,9 +14,13 @@ import { getPropertyBySlug } from "@/lib/properties";
 export const revalidate = 60;
 
 type PropertyPageProps = {
-  params: {
-    slug: string;
-  };
+  params:
+    | {
+        slug: string;
+      }
+    | Promise<{
+        slug: string;
+      }>;
 };
 
 const buildOpenGraphImages = (property: any) => {
@@ -50,7 +54,8 @@ export async function generateStaticParams() {
 }
 
 export async function generateMetadata({ params }: PropertyPageProps): Promise<Metadata> {
-  const property = await getPropertyBySlug({ slug: params.slug });
+  const { slug } = await Promise.resolve(params);
+  const property = await getPropertyBySlug({ slug });
 
   if (!property) {
     return {
@@ -76,14 +81,15 @@ export async function generateMetadata({ params }: PropertyPageProps): Promise<M
       title,
       description,
       type: "article",
-      url: `https://villanuevagarcia.mx/inmuebles/${params.slug}`,
+      url: `https://villanuevagarcia.mx/inmuebles/${slug}`,
       images,
     },
   };
 }
 
 const PropertyPage = async ({ params }: PropertyPageProps) => {
-  const property = await getPropertyBySlug({ slug: params.slug });
+  const { slug } = await Promise.resolve(params);
+  const property = await getPropertyBySlug({ slug });
 
   if (!property) {
     notFound();


### PR DESCRIPTION
## Summary
- allow the property page params to be provided either directly or as a promise
- resolve the slug before using it in metadata generation and the page component

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e1ffa19e6c832384e3c69807f04fe0