### PR TITLE
Generate signed S3 image URLs for property pages

### DIFF
--- a/src/app/inmuebles/[slug]/page.tsx
+++ b/src/app/inmuebles/[slug]/page.tsx
@@ -27,7 +27,7 @@ const buildOpenGraphImages = (property: any) => {
   return (property?.imagenes ?? [])
     .map((image: any) => {
       const imageMetadata = (image.metadata ?? {}) as { alt?: string };
-      const url = image.url ?? image.path;
+      const url = image.signedUrl ?? image.url ?? image.path;
 
       if (!url) {
         return null;
@@ -98,7 +98,7 @@ const PropertyPage = async ({ params }: PropertyPageProps) => {
   const statusName = property.estatus?.nombre ?? "Sin estatus";
   const images = (property.imagenes ?? [])
     .map((image) => ({
-      url: image?.url ?? image?.path ?? "",
+      url: image?.signedUrl ?? image?.url ?? image?.path ?? "",
       alt: (image?.metadata as { alt?: string } | null)?.alt ?? property.titulo ?? "Imagen del inmueble",
     }))
     .filter((image) => Boolean(image.url));


### PR DESCRIPTION
## Summary
- add S3 presigned URL generation when retrieving a property in the shared library
- reuse the signed URLs across property detail views to ensure images load securely
- prioritize the presigned URLs when constructing image metadata for galleries and social previews

## Testing
- not run (per instructions)


------
https://chatgpt.com/codex/tasks/task_e_68e2023936308323bbfa004ecc205dba