### PR TITLE
Improve property gallery styling and freeze map interactions

### DIFF
--- a/src/components/inmuebles/PropertyGallery.tsx
+++ b/src/components/inmuebles/PropertyGallery.tsx
@@ -2,12 +2,11 @@
 
 import { useMemo } from "react";
 import { motion } from "framer-motion";
-import { Navigation, Pagination, Autoplay, EffectCreative } from "swiper/modules";
+import { Navigation, Pagination, Autoplay } from "swiper/modules";
 import { Swiper, SwiperSlide } from "swiper/react";
 import "swiper/css";
 import "swiper/css/navigation";
 import "swiper/css/pagination";
-import "swiper/css/effect-creative";
 
 type GalleryImage = {
   url: string;
@@ -59,43 +58,45 @@ const PropertyGallery = ({ images, title }: PropertyGalleryProps) => {
       transition={{ duration: 0.6, ease: "easeOut" }}
     >
       <Swiper
-        modules={[Navigation, Pagination, Autoplay, EffectCreative]}
+        modules={[Navigation, Pagination, Autoplay]}
         slidesPerView={1}
-        spaceBetween={24}
+        loop
+        centeredSlides
         autoplay={{ delay: 5000, disableOnInteraction: false }}
         navigation
         pagination={{ clickable: true }}
-        effect="creative"
-        creativeEffect={{
-          prev: {
-            shadow: true,
-            translate: ["-20%", 0, -1],
-            rotate: [0, 0, -5],
-          },
-          next: {
-            translate: ["100%", 0, 0],
-          },
-        }}
         className="property-gallery"
       >
         {galleryItems.map((image, index) => (
-          <SwiperSlide key={`${image.url}-${index}`}>
+          <SwiperSlide key={`${image.url}-${index}`} className="!flex items-center justify-center">
             <motion.figure
-              className="relative h-[420px] w-full overflow-hidden rounded-[26px]"
-              whileHover={{ scale: 0.99 }}
+              className="group relative w-full max-w-5xl overflow-hidden rounded-[28px] bg-slate-100/80 shadow-inner"
+              initial={{ opacity: 0.85, scale: 0.98 }}
+              animate={{ opacity: 1, scale: 1 }}
+              transition={{ duration: 0.6, ease: "easeOut" }}
             >
-              <img
-                src={image.url}
-                alt={image.alt ?? title ?? "Imagen del inmueble"}
-                className="h-full w-full object-cover"
-                style={{ background: shimmerBackground }}
-              />
+              <motion.div
+                className="aspect-[16/10] w-full sm:aspect-[16/9]"
+                whileHover={{ scale: 1.01 }}
+                transition={{ duration: 0.4 }}
+              >
+                <img
+                  src={image.url}
+                  alt={image.alt ?? title ?? "Imagen del inmueble"}
+                  className="h-full w-full object-cover transition-transform duration-700 ease-out group-hover:scale-105"
+                  style={{ background: shimmerBackground }}
+                  loading="lazy"
+                />
+              </motion.div>
               <motion.figcaption
-                className="pointer-events-none absolute inset-0 bg-gradient-to-t from-black/55 via-black/0 to-black/10"
+                className="pointer-events-none absolute inset-x-0 bottom-0 bg-gradient-to-t from-black/60 via-black/10 to-black/0 p-6"
                 initial={{ opacity: 0 }}
                 animate={{ opacity: 1 }}
-                transition={{ delay: 0.2, duration: 0.5 }}
-              />
+                transition={{ delay: 0.25, duration: 0.6 }}
+              >
+                <p className="text-sm font-medium uppercase tracking-[0.25em] text-white/80">Galería</p>
+                <p className="text-lg font-semibold text-white drop-shadow">{title}</p>
+              </motion.figcaption>
             </motion.figure>
           </SwiperSlide>
         ))}

--- a/src/components/inmuebles/PropertyMap.tsx
+++ b/src/components/inmuebles/PropertyMap.tsx
@@ -63,7 +63,13 @@ const PropertyMap = ({ latitude, longitude, title, address }: PropertyMapProps) 
       <MapContainer
         center={position}
         zoom={16}
+        dragging={false}
+        doubleClickZoom={false}
+        touchZoom={false}
+        keyboard={false}
+        boxZoom={false}
         scrollWheelZoom={false}
+        zoomControl={false}
         style={{ height: "420px", width: "100%" }}
       >
         <TileLayer


### PR DESCRIPTION
## Summary
- refresh the property gallery slider with a cleaner centered layout, subtle animations, and lazy-loaded images
- disable all interactive gestures on the property map so it remains fixed on the listing location

## Testing
- not run (per instructions)


------
https://chatgpt.com/codex/tasks/task_e_68e205dd6a448323a43afa1bbb4bf80d