### PR TITLE
Update property gallery slider navigation

### DIFF
--- a/src/components/inmuebles/PropertyGallery.tsx
+++ b/src/components/inmuebles/PropertyGallery.tsx
@@ -1,13 +1,14 @@
 "use client";
 
-import { useMemo } from "react";
+import { useEffect, useMemo, useRef } from "react";
 import { motion } from "framer-motion";
-import { Navigation, Pagination, Autoplay, EffectCoverflow } from "swiper/modules";
+import { Navigation, Pagination, Autoplay } from "swiper/modules";
 import { Swiper, SwiperSlide } from "swiper/react";
+import type { Swiper as SwiperInstance } from "swiper";
+import type { NavigationOptions } from "swiper/types";
 import "swiper/css";
 import "swiper/css/navigation";
 import "swiper/css/pagination";
-import "swiper/css/effect-coverflow";
 
 type GalleryImage = {
   url: string;
@@ -31,6 +32,34 @@ const PropertyGallery = ({ images, title }: PropertyGalleryProps) => {
       }))
       .filter((image) => Boolean(image.url));
   }, [images, title]);
+
+  const prevButtonRef = useRef<HTMLButtonElement>(null);
+  const nextButtonRef = useRef<HTMLButtonElement>(null);
+  const swiperRef = useRef<SwiperInstance | null>(null);
+
+  useEffect(() => {
+    const swiper = swiperRef.current;
+
+    if (
+      !swiper ||
+      !swiper.params.navigation ||
+      typeof swiper.params.navigation === "boolean" ||
+      !prevButtonRef.current ||
+      !nextButtonRef.current
+    ) {
+      return;
+    }
+
+    swiper.params.navigation = {
+      ...(swiper.params.navigation as NavigationOptions),
+      prevEl: prevButtonRef.current,
+      nextEl: nextButtonRef.current,
+    };
+
+    swiper.navigation.destroy();
+    swiper.navigation.init();
+    swiper.navigation.update();
+  }, [prevButtonRef, nextButtonRef]);
 
   if (!galleryItems.length) {
     return (
@@ -58,62 +87,99 @@ const PropertyGallery = ({ images, title }: PropertyGalleryProps) => {
       animate={{ opacity: 1, y: 0 }}
       transition={{ duration: 0.6, ease: "easeOut" }}
     >
-      <Swiper
-        modules={[Navigation, Pagination, Autoplay, EffectCoverflow]}
-        effect="coverflow"
-        coverflowEffect={{ rotate: 32, stretch: -10, depth: 140, modifier: 1.2, slideShadows: true }}
-        slidesPerView="auto"
-        centeredSlides
-        loop
-        grabCursor
-        autoplay={{ delay: 5000, disableOnInteraction: false }}
-        navigation
-        pagination={{ clickable: true }}
-        breakpoints={{
-          0: { slidesPerView: 1.1, spaceBetween: 16 },
-          640: { slidesPerView: 1.35, spaceBetween: 24 },
-          1024: { slidesPerView: 2.15, spaceBetween: 32 },
-          1440: { slidesPerView: 2.75, spaceBetween: 40 },
-        }}
-        className="property-gallery !px-4 pb-12"
-      >
-        {galleryItems.map((image, index) => (
-          <SwiperSlide
-            key={`${image.url}-${index}`}
-            className="!flex max-w-[22rem] items-center justify-center sm:max-w-[26rem] md:max-w-[30rem] lg:max-w-[34rem]"
-          >
-            <motion.figure
-              className="group relative w-full overflow-hidden rounded-[32px] bg-slate-100/80 shadow-[0_25px_50px_-12px_rgba(30,64,175,0.35)]"
-              initial={{ opacity: 0.85, scale: 0.94 }}
-              animate={{ opacity: 1, scale: 1 }}
-              transition={{ duration: 0.6, ease: "easeOut" }}
-            >
-              <motion.div
-                className="aspect-[4/5] w-full sm:aspect-[16/10]"
-                whileHover={{ scale: 1.03 }}
-                transition={{ duration: 0.4 }}
+      <div className="relative">
+        <Swiper
+          modules={[Navigation, Pagination, Autoplay]}
+          slidesPerView={1}
+          spaceBetween={24}
+          loop
+          grabCursor
+          autoplay={{ delay: 5000, disableOnInteraction: false }}
+          navigation={{
+            prevEl: prevButtonRef.current,
+            nextEl: nextButtonRef.current,
+          }}
+          pagination={{ clickable: true }}
+          breakpoints={{
+            1024: { spaceBetween: 32 },
+          }}
+          className="property-gallery !px-4 pb-12 [&_.swiper-button-next]:hidden [&_.swiper-button-prev]:hidden"
+          onBeforeInit={(swiper) => {
+            swiperRef.current = swiper;
+
+            if (typeof swiper.params.navigation !== "boolean") {
+              swiper.params.navigation.prevEl = prevButtonRef.current;
+              swiper.params.navigation.nextEl = nextButtonRef.current;
+            }
+          }}
+          onSwiper={(swiper) => {
+            swiperRef.current = swiper;
+          }}
+        >
+          {galleryItems.map((image, index) => (
+            <SwiperSlide key={`${image.url}-${index}`} className="!flex w-full items-center justify-center">
+              <motion.figure
+                className="group relative w-full overflow-hidden rounded-[32px] bg-slate-100/80 shadow-[0_25px_50px_-12px_rgba(30,64,175,0.35)]"
+                initial={{ opacity: 0.85, scale: 0.94 }}
+                animate={{ opacity: 1, scale: 1 }}
+                transition={{ duration: 0.6, ease: "easeOut" }}
               >
-                <img
-                  src={image.url}
-                  alt={image.alt ?? title ?? "Imagen del inmueble"}
-                  className="h-full w-full object-cover transition-transform duration-700 ease-out group-hover:scale-110"
-                  style={{ background: shimmerBackground }}
-                  loading="lazy"
-                />
-              </motion.div>
-              <motion.figcaption
-                className="pointer-events-none absolute inset-x-0 bottom-0 bg-gradient-to-t from-black/70 via-black/20 to-transparent p-6"
-                initial={{ opacity: 0 }}
-                animate={{ opacity: 1 }}
-                transition={{ delay: 0.25, duration: 0.6 }}
-              >
-                <p className="text-[0.65rem] font-medium uppercase tracking-[0.4em] text-white/70">Galería</p>
-                <p className="text-lg font-semibold text-white drop-shadow-lg">{title}</p>
-              </motion.figcaption>
-            </motion.figure>
-          </SwiperSlide>
-        ))}
-      </Swiper>
+                <motion.div
+                  className="aspect-[4/5] w-full sm:aspect-[16/10]"
+                  whileHover={{ scale: 1.03 }}
+                  transition={{ duration: 0.4 }}
+                >
+                  <img
+                    src={image.url}
+                    alt={image.alt ?? title ?? "Imagen del inmueble"}
+                    className="h-full w-full object-cover transition-transform duration-700 ease-out group-hover:scale-110"
+                    style={{ background: shimmerBackground }}
+                    loading="lazy"
+                  />
+                </motion.div>
+                <motion.figcaption
+                  className="pointer-events-none absolute inset-x-0 bottom-0 bg-gradient-to-t from-black/70 via-black/20 to-transparent p-6"
+                  initial={{ opacity: 0 }}
+                  animate={{ opacity: 1 }}
+                  transition={{ delay: 0.25, duration: 0.6 }}
+                >
+                  <p className="text-[0.65rem] font-medium uppercase tracking-[0.4em] text-white/70">Galería</p>
+                  <p className="text-lg font-semibold text-white drop-shadow-lg">{title}</p>
+                </motion.figcaption>
+              </motion.figure>
+            </SwiperSlide>
+          ))}
+        </Swiper>
+
+        <button
+          ref={prevButtonRef}
+          className="absolute -left-10 top-1/2 z-20 hidden h-12 w-12 -translate-y-1/2 items-center justify-center rounded-full bg-white/80 text-[var(--indigo)] shadow-xl transition hover:bg-[var(--lime)] hover:text-black backdrop-blur-md md:flex"
+          aria-label="Ver imagen anterior"
+          type="button"
+        >
+          <svg xmlns="http://www.w3.org/2000/svg" className="h-6 w-6" fill="currentColor" viewBox="0 0 24 24">
+            <path
+              fillRule="evenodd"
+              d="M15.53 4.47a.75.75 0 010 1.06L9.06 12l6.47 6.47a.75.75 0 11-1.06 1.06l-7-7a.75.75 0 010-1.06l7-7a.75.75 0 011.06 0z"
+              clipRule="evenodd"
+            />
+          </svg>
+        </button>
+        <button
+          ref={nextButtonRef}
+          className="absolute -right-10 top-1/2 z-20 hidden h-12 w-12 -translate-y-1/2 items-center justify-center rounded-full bg-white/80 text-[var(--indigo)] shadow-xl transition hover:bg-[var(--lime)] hover:text-black backdrop-blur-md md:flex"
+          aria-label="Ver imagen siguiente"
+          type="button"
+        >
+          <svg xmlns="http://www.w3.org/2000/svg" className="h-6 w-6" fill="currentColor" viewBox="0 0 24 24">
+            <path
+              fillRule="evenodd"
+              d="M8.47 4.47a.75.75 0 011.06 0l7 7a.75.75 0 010 1.06l-7 7a.75.75 0 11-1.06-1.06L14.94 12 8.47 5.53a.75.75 0 010-1.06z"
+              clipRule="evenodd"
+            />
+          </svg>
+        </button>
+      </div>
     </motion.section>
   );
 };


### PR DESCRIPTION
## Summary
- simplify the property gallery slider configuration and remove the coverflow effect
- add custom navigation refs and external buttons while hiding the default swiper controls
- make each gallery slide fill the available width to avoid floating cards

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e20b4a04b88323ab5ae37619c01727