### PR TITLE
Adjust featured properties slider styling

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -69,9 +69,11 @@ body {
 }
 
 .swiper-container {
-  overflow: hidden;
-  padding: 20px;
-  border-radius: 12px;
+  position: relative;
+  overflow: visible;
+  padding: 0;
+  border-radius: 0;
+  background: transparent;
 }
 
 .swiper {
@@ -95,6 +97,17 @@ body {
 .card-3d:hover {
   transform: perspective(1000px) rotateY(6deg) rotateX(2deg) translateY(-5px) scale(1.02);
   box-shadow: 0 20px 40px rgba(0, 0, 0, 0.25), 0 0 25px rgba(210, 255, 30, 0.25);
+}
+
+.featured-properties .card-3d {
+  background: rgba(255, 255, 255, 0.92);
+  border: 1px solid rgba(255, 255, 255, 0.55);
+  box-shadow: 0 22px 45px rgba(15, 23, 42, 0.12);
+  backdrop-filter: blur(12px);
+}
+
+.featured-properties .card-3d:hover {
+  box-shadow: 0 32px 65px rgba(15, 23, 42, 0.18), 0 0 25px rgba(210, 255, 30, 0.25);
 }
 
 .swiper-pagination-bullet {
@@ -167,7 +180,7 @@ body {
 
 @media (max-width: 768px) {
   .swiper-container {
-    padding: 10px;
+    padding: 0;
   }
 
   .card-3d:hover {

--- a/src/components/FeaturedProperties/PropertyCarousel.tsx
+++ b/src/components/FeaturedProperties/PropertyCarousel.tsx
@@ -145,7 +145,7 @@ const PropertyCarousel = ({
 
         return (
           <SwiperSlide key={property.id} className="swiper-slide">
-            <div className="card-3d flex h-full flex-col overflow-hidden rounded-2xl bg-white shadow-md">
+            <div className="card-3d flex h-full flex-col overflow-hidden rounded-2xl border border-white/60 bg-white/90 shadow-none backdrop-blur">
               <div className="relative">
                 <img
                   src={property.coverImageUrl}

--- a/src/components/FeaturedProperties/index.tsx
+++ b/src/components/FeaturedProperties/index.tsx
@@ -16,13 +16,13 @@ const FeaturedProperties = () => {
   );
 
   return (
-    <section id="propiedades" className="bg-[#f1efeb] py-20">
+    <section id="propiedades" className="py-20">
       <div className="mx-auto max-w-7xl px-6">
         <h2 className="mb-12 text-center text-3xl font-bold text-[var(--text-dark)]">
           Propiedades Destacadas
         </h2>
 
-        <div className="relative">
+        <div className="featured-properties relative">
           <div className="swiper-container">
             {isLoading && (
               <div className="flex h-56 items-center justify-center">


### PR DESCRIPTION
## Summary
- remove the grey container background from the featured properties carousel
- refresh the card styling with a translucent surface and soft shadow so the slides float on the page

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e211712e5883238639825dfac5dd57