### PR TITLE
Remove gray shadows from property gallery 3D effect

### DIFF
--- a/src/components/inmuebles/PropertyGallery.tsx
+++ b/src/components/inmuebles/PropertyGallery.tsx
@@ -111,13 +111,13 @@ const PropertyGallery = ({ images, title }: PropertyGalleryProps) => {
 					loop
 					grabCursor
 					autoplay={{ delay: 5000, disableOnInteraction: false }}
-					coverflowEffect={{
-						rotate: 32,
-						stretch: -12,
-						depth: 220,
-						modifier: 1.1,
-						slideShadows: true,
-					}}
+                                        coverflowEffect={{
+                                                rotate: 32,
+                                                stretch: -12,
+                                                depth: 220,
+                                                modifier: 1.1,
+                                                slideShadows: false,
+                                        }}
 					navigation={{
 						prevEl: prevButtonRef.current,
 						nextEl: nextButtonRef.current,


### PR DESCRIPTION
## Summary
- disable Swiper coverflow slide shadows in the property gallery to remove the gray halo behind rotated photos

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e31d95ae888323a169daced740416a