### PR TITLE
Adjust mobile featured card image ratio

### DIFF
--- a/src/components/FeaturedProperties/PropertyCarousel.tsx
+++ b/src/components/FeaturedProperties/PropertyCarousel.tsx
@@ -146,11 +146,11 @@ const PropertyCarousel = ({
         return (
           <SwiperSlide key={property.id} className="swiper-slide">
             <div className="card-3d flex h-full flex-col overflow-hidden rounded-2xl border border-white/60 bg-white/90 shadow-none backdrop-blur">
-              <div className="relative">
+              <div className="relative aspect-[16/9] md:aspect-auto md:h-56">
                 <img
                   src={property.coverImageUrl}
                   alt={property.title}
-                  className="h-56 w-full object-cover"
+                  className="h-full w-full object-cover"
                 />
                 <span className="absolute left-3 top-3 rounded-full bg-[var(--lime)] px-3 py-1 text-xs font-bold text-black">
                   {statusLabel}


### PR DESCRIPTION
## Summary
- enforce a 16:9 aspect ratio for featured property card images on mobile while preserving existing desktop sizing
- ensure cover images stretch to fill the updated container

## Testing
- not run (per instructions)

------
https://chatgpt.com/codex/tasks/task_e_68e31efa4a608323a2e0f4384941210f