### PR TITLE
Prevent duplicate review fetch in AboutSection

### DIFF
--- a/src/components/AboutSection.tsx
+++ b/src/components/AboutSection.tsx
@@ -2,7 +2,7 @@
 
 import { AnimatePresence, motion } from "framer-motion";
 import { Star } from "lucide-react";
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 
 type Review = {
 	displayName: string;
@@ -14,8 +14,16 @@ const AboutSection = () => {
 	const [reviews, setReviews] = useState<Review[]>([]);
 	const [activeIndex, setActiveIndex] = useState(0);
 
-	useEffect(() => {
-		let isMounted = true;
+        const hasFetchedRef = useRef(false);
+
+        useEffect(() => {
+                if (hasFetchedRef.current) {
+                        return;
+                }
+
+                hasFetchedRef.current = true;
+
+                let isMounted = true;
 
 		const fetchReviews = async () => {
 			try {
@@ -86,10 +94,10 @@ const AboutSection = () => {
 
 		fetchReviews();
 
-		return () => {
-			isMounted = false;
-		};
-	}, []);
+                return () => {
+                        isMounted = false;
+                };
+        }, []);
 
 	useEffect(() => {
 		if (!reviews.length) {


### PR DESCRIPTION
## Summary
- add a ref guard in the about section reviews effect to avoid executing the fetch logic twice during React strict mode
- keep the original cleanup logic so the component still cancels state updates when unmounted

## Testing
- not run (per instructions)

------
https://chatgpt.com/codex/tasks/task_e_68e321b273988323b318c659c9369e92