### PR TITLE
Refine property gallery modal layout

### DIFF
--- a/src/components/inmuebles/PropertyGallery.tsx
+++ b/src/components/inmuebles/PropertyGallery.tsx
@@ -330,246 +330,197 @@ const PropertyGallery = ({ images, title }: PropertyGalleryProps) => {
 			{isMounted
 				? createPortal(
 						<AnimatePresence>
-							{isModalOpen ? (
-								<motion.div
-									className="property-gallery-modal fixed inset-0 z-50 flex min-h-[100svh] w-full flex-col bg-black/95 backdrop-blur-sm"
-									initial={{ opacity: 0 }}
-									animate={{ opacity: 1 }}
-									exit={{ opacity: 0 }}
-									onClick={closeModal}
-									role="dialog"
-									aria-modal="true"
-									aria-label="Galería de imágenes"
-								>
-									<motion.div
-										className="relative flex w-full flex-1 flex-col"
-										initial={{ scale: 0.96, opacity: 0 }}
-										animate={{ scale: 1, opacity: 1 }}
-										exit={{ scale: 0.96, opacity: 0 }}
-										transition={{
-											duration: 0.3,
-											ease: "easeOut",
-										}}
-										onClick={(event) =>
-											event.stopPropagation()
-										}
-									>
-										<div
-											className="flex items-center justify-between px-4 text-white sm:hidden"
-											style={{
-												paddingTop:
-													"calc(env(safe-area-inset-top, 0px) + 1rem)",
-												paddingBottom: "1rem",
-											}}
-										>
-											<span
-												className="inline-flex h-10 w-10 flex-none"
-												aria-hidden="true"
-											/>
-											{title ? (
-												<div className="flex min-w-0 flex-1 justify-center">
-													<h2 className="truncate text-base font-medium">
-														{title}
-													</h2>
-												</div>
-											) : (
-												<span className="flex-1" />
-											)}
-											<button
-												type="button"
-												onClick={closeModal}
-												className="ml-4 inline-flex h-10 w-10 items-center justify-center rounded-full bg-white/15 text-white transition hover:bg-white/25"
-												aria-label="Cerrar galería"
-											>
-												<svg
-													xmlns="http://www.w3.org/2000/svg"
-													className="h-5 w-5"
-													fill="none"
-													viewBox="0 0 24 24"
-													stroke="currentColor"
-													strokeWidth={2}
-												>
-													<path
-														strokeLinecap="round"
-														strokeLinejoin="round"
-														d="M6 18L18 6M6 6l12 12"
-													/>
-												</svg>
-											</button>
-										</div>
+                                                        {isModalOpen ? (
+                                                                <motion.div
+                                                                        className="property-gallery-modal fixed inset-0 z-50 flex min-h-[100svh] w-full items-center justify-center bg-black/95"
+                                                                        style={{
+                                                                                paddingTop: "calc(env(safe-area-inset-top, 0px) + 1.25rem)",
+                                                                                paddingBottom: "calc(env(safe-area-inset-bottom, 0px) + 1.25rem)",
+                                                                                paddingLeft: "calc(env(safe-area-inset-left, 0px) + 1rem)",
+                                                                                paddingRight: "calc(env(safe-area-inset-right, 0px) + 1rem)",
+                                                                        }}
+                                                                        initial={{ opacity: 0 }}
+                                                                        animate={{ opacity: 1 }}
+                                                                        exit={{ opacity: 0 }}
+                                                                        onClick={closeModal}
+                                                                        role="dialog"
+                                                                        aria-modal="true"
+                                                                        aria-label="Galería de imágenes"
+                                                                >
+                                                                        <motion.div
+                                                                                className="relative flex h-full w-full max-h-[calc(100svh-2.5rem)] max-w-5xl flex-col overflow-hidden rounded-[28px] border border-white/10 bg-black/75 shadow-[0_45px_120px_-40px_rgba(15,23,42,0.9)] backdrop-blur"
+                                                                                initial={{ scale: 0.96, opacity: 0 }}
+                                                                                animate={{ scale: 1, opacity: 1 }}
+                                                                                exit={{ scale: 0.96, opacity: 0 }}
+                                                                                transition={{
+                                                                                        duration: 0.3,
+                                                                                        ease: "easeOut",
+                                                                                }}
+                                                                                onClick={(event) => event.stopPropagation()}
+                                                                        >
+                                                                                <header className="flex items-start justify-between gap-4 border-b border-white/10 px-4 py-4 text-white sm:px-6 sm:py-5">
+                                                                                        <div className="min-w-0 space-y-1">
+                                                                                                <p className="text-xs font-semibold uppercase tracking-[0.25em] text-white/50">
+                                                                                                        Galería
+                                                                                                </p>
+                                                                                                {title && (
+                                                                                                        <h2 className="truncate text-lg font-semibold sm:text-xl">
+                                                                                                                {title}
+                                                                                                        </h2>
+                                                                                                )}
+                                                                                        </div>
 
-										<div className="relative flex flex-1 items-center justify-center px-4 pb-10 pt-4 sm:px-8 sm:pb-12">
-											<motion.img
-												key={
-													galleryItems[activeIndex]
-														?.url
-												}
-												src={
-													galleryItems[activeIndex]
-														?.url
-												}
-												alt={
-													galleryItems[activeIndex]
-														?.alt ??
-													title ??
-													"Imagen del inmueble"
-												}
-												className="max-h-full w-full max-w-full cursor-zoom-in object-contain"
-												initial={{ opacity: 0, y: 20 }}
-												animate={{ opacity: 1, y: 0 }}
-												transition={{
-													duration: 0.4,
-													ease: "easeOut",
-												}}
-											/>
+                                                                                        <button
+                                                                                                type="button"
+                                                                                                onClick={closeModal}
+                                                                                                className="inline-flex h-11 w-11 shrink-0 items-center justify-center rounded-full bg-white/10 text-white transition hover:bg-white/20 focus:outline-none focus-visible:ring-2 focus-visible:ring-white/40"
+                                                                                                aria-label="Cerrar galería"
+                                                                                        >
+                                                                                                <svg
+                                                                                                        xmlns="http://www.w3.org/2000/svg"
+                                                                                                        className="h-5 w-5"
+                                                                                                        fill="none"
+                                                                                                        viewBox="0 0 24 24"
+                                                                                                        stroke="currentColor"
+                                                                                                        strokeWidth={2}
+                                                                                                >
+                                                                                                        <path
+                                                                                                                strokeLinecap="round"
+                                                                                                                strokeLinejoin="round"
+                                                                                                                d="M6 18L18 6M6 6l12 12"
+                                                                                                        />
+                                                                                                </svg>
+                                                                                        </button>
+                                                                                </header>
 
-											<button
-												type="button"
-												onClick={closeModal}
-												className="absolute right-6 top-6 z-10 hidden h-12 w-12 items-center justify-center rounded-full bg-white/20 text-white backdrop-blur-sm transition hover:bg-white/30 sm:flex md:h-14 md:w-14"
-												aria-label="Cerrar galería"
-											>
-												<svg
-													xmlns="http://www.w3.org/2000/svg"
-													className="h-6 w-6 md:h-7 md:w-7"
-													fill="none"
-													viewBox="0 0 24 24"
-													stroke="currentColor"
-													strokeWidth={2}
-												>
-													<path
-														strokeLinecap="round"
-														strokeLinejoin="round"
-														d="M6 18L18 6M6 6l12 12"
-													/>
-												</svg>
-											</button>
+                                                                                <div className="relative flex flex-1 items-center justify-center bg-gradient-to-b from-black/30 via-black/50 to-black/70 px-3 py-6 sm:px-8 sm:py-10">
+                                                                                        <motion.img
+                                                                                                key={galleryItems[activeIndex]?.url}
+                                                                                                src={galleryItems[activeIndex]?.url}
+                                                                                                alt={
+                                                                                                        galleryItems[activeIndex]?.alt ??
+                                                                                                        title ??
+                                                                                                        "Imagen del inmueble"
+                                                                                                }
+                                                                                                className="max-h-full w-full max-w-full cursor-zoom-in object-contain"
+                                                                                                initial={{ opacity: 0, y: 20 }}
+                                                                                                animate={{ opacity: 1, y: 0 }}
+                                                                                                transition={{
+                                                                                                        duration: 0.4,
+                                                                                                        ease: "easeOut",
+                                                                                                }}
+                                                                                        />
 
-											{galleryItems.length > 1 && (
-												<>
-													<button
-														type="button"
-														onClick={showPrevious}
-														className="absolute left-3 top-1/2 z-10 hidden -translate-y-1/2 transform items-center justify-center rounded-full bg-white/20 text-white backdrop-blur-sm transition hover:bg-white/30 sm:flex h-12 w-12 md:left-6 md:h-14 md:w-14"
-														aria-label="Imagen anterior"
-													>
-														<svg
-															xmlns="http://www.w3.org/2000/svg"
-															className="h-6 w-6 md:h-7 md:w-7"
-															fill="none"
-															viewBox="0 0 24 24"
-															stroke="currentColor"
-															strokeWidth={2}
-														>
-															<path
-																strokeLinecap="round"
-																strokeLinejoin="round"
-																d="M15 19l-7-7 7-7"
-															/>
-														</svg>
-													</button>
-													<button
-														type="button"
-														onClick={showNext}
-														className="absolute right-3 top-1/2 z-10 hidden -translate-y-1/2 transform items-center justify-center rounded-full bg-white/20 text-white backdrop-blur-sm transition hover:bg-white/30 sm:flex h-12 w-12 md:right-6 md:h-14 md:w-14"
-														aria-label="Imagen siguiente"
-													>
-														<svg
-															xmlns="http://www.w3.org/2000/svg"
-															className="h-6 w-6 md:h-7 md:w-7"
-															fill="none"
-															viewBox="0 0 24 24"
-															stroke="currentColor"
-															strokeWidth={2}
-														>
-															<path
-																strokeLinecap="round"
-																strokeLinejoin="round"
-																d="M9 5l7 7-7 7"
-															/>
-														</svg>
-													</button>
-												</>
-											)}
+                                                                                        {galleryItems.length > 1 && (
+                                                                                                <>
+                                                                                                        <button
+                                                                                                                type="button"
+                                                                                                                onClick={showPrevious}
+                                                                                                                className="absolute left-4 top-1/2 z-10 hidden -translate-y-1/2 transform items-center justify-center rounded-full bg-white/15 text-white backdrop-blur-sm transition hover:bg-white/25 sm:flex h-12 w-12 md:left-6 md:h-14 md:w-14"
+                                                                                                                aria-label="Imagen anterior"
+                                                                                                        >
+                                                                                                                <svg
+                                                                                                                        xmlns="http://www.w3.org/2000/svg"
+                                                                                                                        className="h-6 w-6 md:h-7 md:w-7"
+                                                                                                                        fill="none"
+                                                                                                                        viewBox="0 0 24 24"
+                                                                                                                        stroke="currentColor"
+                                                                                                                        strokeWidth={2}
+                                                                                                                >
+                                                                                                                        <path
+                                                                                                                                strokeLinecap="round"
+                                                                                                                                strokeLinejoin="round"
+                                                                                                                                d="M15 19l-7-7 7-7"
+                                                                                                                        />
+                                                                                                                </svg>
+                                                                                                        </button>
+                                                                                                        <button
+                                                                                                                type="button"
+                                                                                                                onClick={showNext}
+                                                                                                                className="absolute right-4 top-1/2 z-10 hidden -translate-y-1/2 transform items-center justify-center rounded-full bg-white/15 text-white backdrop-blur-sm transition hover:bg-white/25 sm:flex h-12 w-12 md:right-6 md:h-14 md:w-14"
+                                                                                                                aria-label="Imagen siguiente"
+                                                                                                        >
+                                                                                                                <svg
+                                                                                                                        xmlns="http://www.w3.org/2000/svg"
+                                                                                                                        className="h-6 w-6 md:h-7 md:w-7"
+                                                                                                                        fill="none"
+                                                                                                                        viewBox="0 0 24 24"
+                                                                                                                        stroke="currentColor"
+                                                                                                                        strokeWidth={2}
+                                                                                                                >
+                                                                                                                        <path
+                                                                                                                                strokeLinecap="round"
+                                                                                                                                strokeLinejoin="round"
+                                                                                                                                d="M9 5l7 7-7 7"
+                                                                                                                        />
+                                                                                                                </svg>
+                                                                                                        </button>
+                                                                                                </>
+                                                                                        )}
 
-											{galleryItems.length > 1 && (
-												<div className="absolute bottom-6 left-1/2 z-10 hidden -translate-x-1/2 transform rounded-full bg-black/50 px-4 py-2 text-center text-sm font-medium text-white backdrop-blur-sm sm:block md:text-base">
-													{activeIndex + 1} /{" "}
-													{galleryItems.length}
-												</div>
-											)}
+                                                                                        {galleryItems.length > 1 && (
+                                                                                                <div className="absolute bottom-6 left-1/2 z-10 hidden -translate-x-1/2 transform rounded-full bg-black/60 px-4 py-2 text-center text-sm font-medium text-white backdrop-blur sm:block md:text-base">
+                                                                                                        {activeIndex + 1} / {galleryItems.length}
+                                                                                                </div>
+                                                                                        )}
+                                                                                </div>
 
-											{title && (
-												<div className="absolute left-6 top-6 z-10 hidden max-w-xs truncate text-white sm:hidden lg:block">
-													<h2 className="text-lg font-semibold">
-														{title}
-													</h2>
-												</div>
-											)}
-										</div>
+                                                                                {galleryItems.length > 1 && (
+                                                                                        <footer className="flex items-center justify-between gap-6 border-t border-white/10 px-4 py-4 text-white sm:hidden">
+                                                                                                <button
+                                                                                                        type="button"
+                                                                                                        onClick={showPrevious}
+                                                                                                        className="inline-flex h-12 w-12 items-center justify-center rounded-full bg-white/15 text-white transition hover:bg-white/25"
+                                                                                                        aria-label="Imagen anterior"
+                                                                                                >
+                                                                                                        <svg
+                                                                                                                xmlns="http://www.w3.org/2000/svg"
+                                                                                                                className="h-5 w-5"
+                                                                                                                fill="none"
+                                                                                                                viewBox="0 0 24 24"
+                                                                                                                stroke="currentColor"
+                                                                                                                strokeWidth={2}
+                                                                                                        >
+                                                                                                                <path
+                                                                                                                        strokeLinecap="round"
+                                                                                                                        strokeLinejoin="round"
+                                                                                                                        d="M15 19l-7-7 7-7"
+                                                                                                                />
+                                                                                                        </svg>
+                                                                                                </button>
 
-										{galleryItems.length > 1 && (
-											<div
-												className="flex items-center justify-between px-4 text-white sm:hidden"
-												style={{
-													paddingBottom:
-														"calc(env(safe-area-inset-bottom, 0px) + 1.25rem)",
-												}}
-											>
-												<button
-													type="button"
-													onClick={showPrevious}
-													className="inline-flex h-12 w-12 items-center justify-center rounded-full bg-white/15 text-white transition hover:bg-white/25"
-													aria-label="Imagen anterior"
-												>
-													<svg
-														xmlns="http://www.w3.org/2000/svg"
-														className="h-5 w-5"
-														fill="none"
-														viewBox="0 0 24 24"
-														stroke="currentColor"
-														strokeWidth={2}
-													>
-														<path
-															strokeLinecap="round"
-															strokeLinejoin="round"
-															d="M15 19l-7-7 7-7"
-														/>
-													</svg>
-												</button>
+                                                                                                <div className="text-sm font-medium">
+                                                                                                        {activeIndex + 1} / {galleryItems.length}
+                                                                                                </div>
 
-												<div className="text-sm font-medium">
-													{activeIndex + 1} /{" "}
-													{galleryItems.length}
-												</div>
+                                                                                                <button
+                                                                                                        type="button"
+                                                                                                        onClick={showNext}
+                                                                                                        className="inline-flex h-12 w-12 items-center justify-center rounded-full bg-white/15 text-white transition hover:bg-white/25"
+                                                                                                        aria-label="Imagen siguiente"
+                                                                                                >
+                                                                                                        <svg
+                                                                                                                xmlns="http://www.w3.org/2000/svg"
+                                                                                                                className="h-5 w-5"
+                                                                                                                fill="none"
+                                                                                                                viewBox="0 0 24 24"
+                                                                                                                stroke="currentColor"
+                                                                                                                strokeWidth={2}
+                                                                                                        >
+                                                                                                                <path
+                                                                                                                        strokeLinecap="round"
+                                                                                                                        strokeLinejoin="round"
+                                                                                                                        d="M9 5l7 7-7 7"
+                                                                                                                />
+                                                                                                        </svg>
+                                                                                                </button>
+                                                                                        </footer>
+                                                                                )}
+                                                                        </motion.div>
+                                                                </motion.div>
+                                                        ) : null}
+                                                </AnimatePresence>,
 
-												<button
-													type="button"
-													onClick={showNext}
-													className="inline-flex h-12 w-12 items-center justify-center rounded-full bg-white/15 text-white transition hover:bg-white/25"
-													aria-label="Imagen siguiente"
-												>
-													<svg
-														xmlns="http://www.w3.org/2000/svg"
-														className="h-5 w-5"
-														fill="none"
-														viewBox="0 0 24 24"
-														stroke="currentColor"
-														strokeWidth={2}
-													>
-														<path
-															strokeLinecap="round"
-															strokeLinejoin="round"
-															d="M9 5l7 7-7 7"
-														/>
-													</svg>
-												</button>
-											</div>
-										)}
-									</motion.div>
-								</motion.div>
-							) : null}
-						</AnimatePresence>,
 						document.body
 				  )
 				: null}


### PR DESCRIPTION
## Summary
- center the property gallery modal within the visible viewport using safe-area padding and a max-height constraint
- reorganize the modal header, body, and mobile footer controls for a mobile-first navigation flow while keeping desktop floating buttons

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e3441a44c483238336701ccd6fb999