### PR TITLE
Guard Swiper navigation params before assigning refs

### DIFF
--- a/src/components/FeaturedProperties/PropertyCarousel.tsx
+++ b/src/components/FeaturedProperties/PropertyCarousel.tsx
@@ -112,9 +112,11 @@ const PropertyCarousel = ({
       onBeforeInit={(swiper) => {
         swiperRef.current = swiper;
 
-        if (typeof swiper.params.navigation !== "boolean") {
-          swiper.params.navigation.prevEl = navigationPrevRef.current;
-          swiper.params.navigation.nextEl = navigationNextRef.current;
+        if (swiper.params.navigation && typeof swiper.params.navigation !== "boolean") {
+          const navigation = swiper.params.navigation;
+
+          navigation.prevEl = navigationPrevRef.current;
+          navigation.nextEl = navigationNextRef.current;
         }
 
         if (typeof swiper.params.pagination !== "boolean") {

--- a/src/components/inmuebles/PropertyGallery.tsx
+++ b/src/components/inmuebles/PropertyGallery.tsx
@@ -598,16 +598,19 @@ const PropertyGallery = ({ images, title }: PropertyGalleryProps) => {
 						},
 					}}
 					className="property-gallery !px-4 pb-12 [&_.swiper-button-next]:hidden [&_.swiper-button-prev]:hidden"
-					onBeforeInit={(swiper) => {
-						swiperRef.current = swiper;
+                                        onBeforeInit={(swiper) => {
+                                                swiperRef.current = swiper;
 
-						if (typeof swiper.params.navigation !== "boolean") {
-							swiper.params.navigation.prevEl =
-								thumbnailPrevButtonRef.current;
-							swiper.params.navigation.nextEl =
-								thumbnailNextButtonRef.current;
-						}
-					}}
+                                                if (
+                                                        swiper.params.navigation &&
+                                                        typeof swiper.params.navigation !== "boolean"
+                                                ) {
+                                                        const navigation = swiper.params.navigation;
+
+                                                        navigation.prevEl = thumbnailPrevButtonRef.current;
+                                                        navigation.nextEl = thumbnailNextButtonRef.current;
+                                                }
+                                        }}
 					onSwiper={(swiper) => {
 						swiperRef.current = swiper;
 					}}


### PR DESCRIPTION
## Summary
- guard Swiper navigation parameters before assigning navigation refs in the property gallery
- apply the same safety check in the featured properties carousel to prevent undefined navigation configuration

## Testing
- not run (per instructions)


------
https://chatgpt.com/codex/tasks/task_e_68e355679c50832391956dfd78bad505