### PR TITLE
Fix blur effect affecting mobile property gallery modal

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -39,7 +39,7 @@ html.gallery-modal-open body {
   overflow: hidden;
 }
 
-html.gallery-modal-open body > *:not(.property-gallery-modal) {
+html.gallery-modal-open body > *:not(.property-gallery-modal):not(.property-gallery-modal-mobile) {
   filter: blur(14px);
   transition: filter 0.35s ease;
 }


### PR DESCRIPTION
## Summary
- update the gallery modal blur selector so the mobile modal content stays sharp

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e3560b580c8323b80e33b143c6b652