### PR TITLE
Center featured properties carousel when slides are limited

### DIFF
--- a/src/components/FeaturedProperties/PropertyCarousel.tsx
+++ b/src/components/FeaturedProperties/PropertyCarousel.tsx
@@ -87,16 +87,18 @@ const PropertyCarousel = ({
 	}, [navigationPrevRef, navigationNextRef, paginationRef]);
 
 	return (
-		<Swiper
-			modules={[Navigation, Pagination]}
-			className="swiper mySwiper"
-			spaceBetween={30}
-			slidesPerView={1}
-			loop={shouldLoop}
-			navigation={{
-				prevEl: navigationPrevRef.current,
-				nextEl: navigationNextRef.current,
-			}}
+                <Swiper
+                        modules={[Navigation, Pagination]}
+                        className="swiper mySwiper"
+                        spaceBetween={30}
+                        slidesPerView={1}
+                        loop={shouldLoop}
+                        centeredSlides={properties.length < 3}
+                        centerInsufficientSlides
+                        navigation={{
+                                prevEl: navigationPrevRef.current,
+                                nextEl: navigationNextRef.current,
+                        }}
 			pagination={{
 				el: paginationRef.current,
 				clickable: true,


### PR DESCRIPTION
## Summary
- center slides in the featured properties carousel when there are only a few items

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e371e426948323b6cd658277cf4b2d