### PR TITLE
Center featured property cards on homepage

### DIFF
--- a/src/components/FeaturedProperties/PropertyCarousel.tsx
+++ b/src/components/FeaturedProperties/PropertyCarousel.tsx
@@ -87,7 +87,7 @@ const PropertyCarousel = ({
 	}, [navigationPrevRef, navigationNextRef, paginationRef]);
 
 	return (
-		<Swiper
+                <Swiper
 			modules={[Navigation, Pagination]}
 			className="swiper mySwiper"
 			spaceBetween={30}
@@ -132,7 +132,7 @@ const PropertyCarousel = ({
 				swiperRef.current = swiper;
 			}}
 		>
-			{properties.map((property) => {
+                        {properties.map((property) => {
 				const formattedPrice = Number.isFinite(property.price)
 					? currencyFormatter.format(property.price)
 					: "Consultar";
@@ -151,9 +151,12 @@ const PropertyCarousel = ({
 
 				const detailsLine = detailsLineItems.join(" · ");
 
-				return (
-					<SwiperSlide key={property.id} className="swiper-slide">
-						<div className="card-3d flex h-full flex-col overflow-hidden rounded-2xl border border-white/60 bg-white/90 shadow-none backdrop-blur">
+                                return (
+                                        <SwiperSlide
+                                                key={property.id}
+                                                className="swiper-slide flex justify-center"
+                                        >
+                                                <div className="card-3d flex h-full w-full max-w-sm flex-col overflow-hidden rounded-2xl border border-white/60 bg-white/90 shadow-none backdrop-blur">
 							<div className="relative aspect-[16/9] md:aspect-auto md:h-56">
 								<img
 									src={property.coverImageUrl}

--- a/src/components/FeaturedProperties/index.tsx
+++ b/src/components/FeaturedProperties/index.tsx
@@ -22,8 +22,8 @@ const FeaturedProperties = () => {
           Propiedades Destacadas
         </h2>
 
-        <div className="featured-properties relative">
-          <div className="swiper-container">
+        <div className="featured-properties relative mx-auto flex max-w-6xl flex-col items-center">
+          <div className="swiper-container w-full">
             {isLoading && (
               <div className="flex h-56 items-center justify-center">
                 <p className="text-gray-500">Cargando propiedades…</p>


### PR DESCRIPTION
## Summary
- center the featured properties container within the homepage section for better balance
- limit each carousel card width and center slides to keep highlighted items aligned

## Testing
- not run (per instructions)


------
https://chatgpt.com/codex/tasks/task_e_68e3765815488323b5267a777b3fd885