### PR TITLE
Adjust featured properties carousel for dynamic slide counts

### DIFF
--- a/src/components/FeaturedProperties/PropertyCarousel.tsx
+++ b/src/components/FeaturedProperties/PropertyCarousel.tsx
@@ -42,7 +42,15 @@ const PropertyCarousel = ({
 	paginationRef,
 }: PropertyCarouselProps) => {
 	const swiperRef = useRef<SwiperInstance | null>(null);
-	const shouldLoop = properties.length > 3;
+        const totalProperties = properties.length;
+        const shouldLoop = totalProperties > 3;
+        const slidesPerViewFor = (desired: number) => {
+                if (totalProperties <= 0) {
+                        return 1;
+                }
+
+                return Math.min(desired, totalProperties);
+        };
 
 	useEffect(() => {
 		const swiper = swiperRef.current;
@@ -103,14 +111,14 @@ const PropertyCarousel = ({
 				el: paginationRef.current,
 				clickable: true,
 			}}
-			breakpoints={{
-				768: {
-					slidesPerView: 2,
-				},
-				1024: {
-					slidesPerView: 3,
-				},
-			}}
+                        breakpoints={{
+                                768: {
+                                        slidesPerView: slidesPerViewFor(2),
+                                },
+                                1024: {
+                                        slidesPerView: slidesPerViewFor(3),
+                                },
+                        }}
 			onBeforeInit={(swiper) => {
 				swiperRef.current = swiper;
 


### PR DESCRIPTION
## Summary
- prevent the featured properties carousel from reserving empty slots when there are few items
- compute breakpoint slide counts dynamically so a single card stays centered

## Testing
- not run (per instructions)

------
https://chatgpt.com/codex/tasks/task_e_68e453f1a288832395680c6f41fa4a42