### PR TITLE
Center single featured property card in carousel

### DIFF
--- a/src/components/FeaturedProperties/PropertyCarousel.tsx
+++ b/src/components/FeaturedProperties/PropertyCarousel.tsx
@@ -94,10 +94,16 @@ const PropertyCarousel = ({
 		}
 	}, [navigationPrevRef, navigationNextRef, paginationRef]);
 
-	return (
+        const swiperClassName = ["swiper mySwiper"];
+
+        if (totalProperties === 1) {
+                swiperClassName.push("mx-auto max-w-sm");
+        }
+
+        return (
                 <Swiper
-			modules={[Navigation, Pagination]}
-			className="swiper mySwiper"
+                        modules={[Navigation, Pagination]}
+                        className={swiperClassName.join(" ")}
 			spaceBetween={30}
 			slidesPerView={1}
 			loop={shouldLoop}

--- a/src/components/FeaturedProperties/index.tsx
+++ b/src/components/FeaturedProperties/index.tsx
@@ -23,7 +23,7 @@ const FeaturedProperties = () => {
         </h2>
 
         <div className="featured-properties relative mx-auto flex max-w-6xl flex-col items-center ">
-          <div className="swiper-container w-full border border-red-500 ">
+          <div className="swiper-container w-full ">
             {isLoading && (
               <div className="flex h-56 items-center justify-center">
                 <p className="text-gray-500">Cargando propiedades…</p>


### PR DESCRIPTION
## Summary
- remove temporary debug border styles from the featured properties swiper container
- center the Swiper instance when only one property is available so the card stays centered

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e45599954483239e48cea1ad52c363