### PR TITLE
Center two featured properties in carousel

### DIFF
--- a/src/components/FeaturedProperties/PropertyCarousel.tsx
+++ b/src/components/FeaturedProperties/PropertyCarousel.tsx
@@ -98,6 +98,8 @@ const PropertyCarousel = ({
 
         if (totalProperties === 1) {
                 swiperClassName.push("mx-auto max-w-sm");
+        } else if (totalProperties === 2) {
+                swiperClassName.push("mx-auto max-w-4xl");
         }
 
         return (


### PR DESCRIPTION
## Summary
- center the featured properties carousel when only two properties are available by constraining the swiper width

## Testing
- not run (per instructions)


------
https://chatgpt.com/codex/tasks/task_e_68e45a8b6a948323b9875bb2a711daca