### PR TITLE
Fix featured properties carousel when limited items

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -91,12 +91,16 @@ html.gallery-modal-open body {
 }
 
 .swiper-slide {
-	z-index: 50;
+        z-index: 50;
+}
+
+.swiper.two-slides .swiper-wrapper {
+        justify-content: center;
 }
 
 .card-3d {
-	transform-style: preserve-3d;
-	transition: transform 0.4s ease, box-shadow 0.4s ease;
+        transform-style: preserve-3d;
+        transition: transform 0.4s ease, box-shadow 0.4s ease;
 }
 
 .card-3d:hover {

--- a/src/components/FeaturedProperties/PropertyCarousel.tsx
+++ b/src/components/FeaturedProperties/PropertyCarousel.tsx
@@ -41,9 +41,10 @@ const PropertyCarousel = ({
 	navigationNextRef,
 	paginationRef,
 }: PropertyCarouselProps) => {
-	const swiperRef = useRef<SwiperInstance | null>(null);
+        const swiperRef = useRef<SwiperInstance | null>(null);
         const totalProperties = properties.length;
         const shouldLoop = totalProperties > 3;
+        const enableNavigation = totalProperties > 2;
         const slidesPerViewFor = (desired: number) => {
                 if (totalProperties <= 0) {
                         return 1;
@@ -59,22 +60,25 @@ const PropertyCarousel = ({
 			return;
 		}
 
-		if (
-			swiper.params.navigation &&
-			typeof swiper.params.navigation !== "boolean" &&
-			navigationPrevRef.current &&
-			navigationNextRef.current
-		) {
-			swiper.params.navigation = {
-				...(swiper.params.navigation as NavigationOptions),
-				prevEl: navigationPrevRef.current,
-				nextEl: navigationNextRef.current,
-			};
+                if (
+                        enableNavigation &&
+                        swiper.params.navigation &&
+                        typeof swiper.params.navigation !== "boolean" &&
+                        navigationPrevRef.current &&
+                        navigationNextRef.current
+                ) {
+                        swiper.params.navigation = {
+                                ...(swiper.params.navigation as NavigationOptions),
+                                prevEl: navigationPrevRef.current,
+                                nextEl: navigationNextRef.current,
+                        };
 
-			swiper.navigation.destroy();
-			swiper.navigation.init();
-			swiper.navigation.update();
-		}
+                        swiper.navigation.destroy();
+                        swiper.navigation.init();
+                        swiper.navigation.update();
+                } else if (!enableNavigation && swiper.navigation) {
+                        swiper.navigation.destroy();
+                }
 
 		if (
 			swiper.params.pagination &&
@@ -92,7 +96,7 @@ const PropertyCarousel = ({
 			swiper.pagination.render();
 			swiper.pagination.update();
 		}
-	}, [navigationPrevRef, navigationNextRef, paginationRef]);
+        }, [enableNavigation, navigationPrevRef, navigationNextRef, paginationRef]);
 
         const swiperClassName = ["swiper mySwiper"];
 
@@ -100,21 +104,26 @@ const PropertyCarousel = ({
                 swiperClassName.push("mx-auto max-w-sm");
         } else if (totalProperties === 2) {
                 swiperClassName.push("mx-auto max-w-4xl");
+                swiperClassName.push("two-slides");
         }
 
         return (
                 <Swiper
-                        modules={[Navigation, Pagination]}
+                        modules={enableNavigation ? [Navigation, Pagination] : [Pagination]}
                         className={swiperClassName.join(" ")}
 			spaceBetween={30}
 			slidesPerView={1}
 			loop={shouldLoop}
 			centeredSlides={properties.length < 3}
 			centerInsufficientSlides
-			navigation={{
-				prevEl: navigationPrevRef.current,
-				nextEl: navigationNextRef.current,
-			}}
+                        navigation={
+                                enableNavigation
+                                        ? {
+                                                  prevEl: navigationPrevRef.current,
+                                                  nextEl: navigationNextRef.current,
+                                          }
+                                        : false
+                        }
 			pagination={{
 				el: paginationRef.current,
 				clickable: true,
@@ -130,15 +139,18 @@ const PropertyCarousel = ({
 			onBeforeInit={(swiper) => {
 				swiperRef.current = swiper;
 
-				if (
-					swiper.params.navigation &&
-					typeof swiper.params.navigation !== "boolean"
-				) {
-					const navigation = swiper.params.navigation;
+                                if (
+                                        enableNavigation &&
+                                        swiper.params.navigation &&
+                                        typeof swiper.params.navigation !== "boolean"
+                                ) {
+                                        const navigation = swiper.params.navigation;
 
-					navigation.prevEl = navigationPrevRef.current;
-					navigation.nextEl = navigationNextRef.current;
-				}
+                                        navigation.prevEl = navigationPrevRef.current;
+                                        navigation.nextEl = navigationNextRef.current;
+                                } else if (!enableNavigation) {
+                                        swiper.params.navigation = false;
+                                }
 
 				if (typeof swiper.params.pagination !== "boolean") {
 					swiper.params.pagination.el = paginationRef.current;

--- a/src/components/FeaturedProperties/index.tsx
+++ b/src/components/FeaturedProperties/index.tsx
@@ -14,6 +14,8 @@ const FeaturedProperties = () => {
     () => mapPropertiesFromApi(apiProperties),
     [apiProperties],
   );
+  const totalProperties = properties.length;
+  const showDesktopNavigation = totalProperties > 2;
 
   return (
     <section id="propiedades" className="py-20">
@@ -36,7 +38,7 @@ const FeaturedProperties = () => {
               </div>
             )}
 
-            {!isLoading && !error && properties.length === 0 && (
+            {!isLoading && !error && totalProperties === 0 && (
               <div className="flex h-56 items-center justify-center">
                 <p className="text-gray-500">
                   No hay propiedades destacadas disponibles por ahora.
@@ -44,7 +46,7 @@ const FeaturedProperties = () => {
               </div>
             )}
 
-            {!isLoading && !error && properties.length > 0 && (
+            {!isLoading && !error && totalProperties > 0 && (
               <PropertyCarousel
                 properties={properties}
                 navigationPrevRef={prevRef}
@@ -56,7 +58,7 @@ const FeaturedProperties = () => {
 
           <button
             ref={prevRef}
-            className="nav-prev absolute -left-16 top-1/2 z-20 hidden h-12 w-12 -translate-y-1/2 items-center justify-center rounded-full bg-white/80 text-[var(--indigo)] shadow-xl transition hover:bg-[var(--lime)] hover:text-black backdrop-blur-md md:flex"
+            className={`nav-prev absolute -left-16 top-1/2 z-20 hidden h-12 w-12 -translate-y-1/2 items-center justify-center rounded-full bg-white/80 text-[var(--indigo)] shadow-xl transition hover:bg-[var(--lime)] hover:text-black backdrop-blur-md ${showDesktopNavigation ? "md:flex" : "md:hidden"}`}
             aria-label="Ver propiedad anterior"
             type="button"
           >
@@ -70,7 +72,7 @@ const FeaturedProperties = () => {
           </button>
           <button
             ref={nextRef}
-            className="nav-next absolute -right-16 top-1/2 z-20 hidden h-12 w-12 -translate-y-1/2 items-center justify-center rounded-full bg-white/80 text-[var(--indigo)] shadow-xl transition hover:bg-[var(--lime)] hover:text-black backdrop-blur-md md:flex"
+            className={`nav-next absolute -right-16 top-1/2 z-20 hidden h-12 w-12 -translate-y-1/2 items-center justify-center rounded-full bg-white/80 text-[var(--indigo)] shadow-xl transition hover:bg-[var(--lime)] hover:text-black backdrop-blur-md ${showDesktopNavigation ? "md:flex" : "md:hidden"}`}
             aria-label="Ver siguiente propiedad"
             type="button"
           >


### PR DESCRIPTION
## Summary
- hide the desktop navigation arrows and reuse pagination when there are two featured properties
- guard the Swiper navigation setup and add styling so pairs of cards stay centered

## Testing
- not run (per instructions)


------
https://chatgpt.com/codex/tasks/task_e_68e45ded28488323b6104eb2c64b2827