### PR TITLE
Fix mobile overflow clipping in swiper

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -74,20 +74,20 @@ html.gallery-modal-open body {
 }
 
 .swiper-container {
-	position: relative;
-	overflow: visible;
-	padding: 0;
-	border-radius: 0;
-	background: transparent;
+        position: relative;
+        overflow: hidden;
+        padding: 0;
+        border-radius: 0;
+        background: transparent;
 }
 
 .swiper {
-	overflow: visible !important;
-	padding: 0;
+        overflow: hidden;
+        padding: 0;
 }
 
 .swiper-wrapper {
-	overflow: visible !important;
+        overflow: hidden;
 }
 
 .swiper-slide {
@@ -96,6 +96,14 @@ html.gallery-modal-open body {
 
 .swiper.two-slides .swiper-wrapper {
         justify-content: center;
+}
+
+@media (min-width: 768px) {
+        .swiper-container,
+        .swiper,
+        .swiper-wrapper {
+                overflow: visible;
+        }
 }
 
 .card-3d {


### PR DESCRIPTION
## Summary
- restore swiper containers to use hidden overflow by default to prevent cards from spilling on mobile
- re-enable visible overflow for swiper elements on viewports 768px and up to preserve the desktop 3D effect

## Testing
- not run (per instructions)

------
https://chatgpt.com/codex/tasks/task_e_68e4856929a48323ba818c3d4f4c5ad4