### PR TITLE
Adjust featured properties carousel layout

### DIFF
--- a/src/components/FeaturedProperties/PropertyCarousel.tsx
+++ b/src/components/FeaturedProperties/PropertyCarousel.tsx
@@ -44,7 +44,8 @@ const PropertyCarousel = ({
         const swiperRef = useRef<SwiperInstance | null>(null);
         const totalProperties = properties.length;
         const shouldLoop = totalProperties > 3;
-        const enableNavigation = totalProperties > 2;
+        const enableNavigation = totalProperties > 3;
+        const allowSwipe = totalProperties > 1;
         const slidesPerViewFor = (desired: number) => {
                 if (totalProperties <= 0) {
                         return 1;
@@ -124,6 +125,7 @@ const PropertyCarousel = ({
                                           }
                                         : false
                         }
+                        allowTouchMove={allowSwipe}
 			pagination={{
 				el: paginationRef.current,
 				clickable: true,

--- a/src/components/FeaturedProperties/index.tsx
+++ b/src/components/FeaturedProperties/index.tsx
@@ -15,7 +15,7 @@ const FeaturedProperties = () => {
     [apiProperties],
   );
   const totalProperties = properties.length;
-  const showDesktopNavigation = totalProperties > 2;
+  const showDesktopNavigation = totalProperties > 3;
 
   return (
     <section id="propiedades" className="py-20">
@@ -87,7 +87,10 @@ const FeaturedProperties = () => {
         </div>
 
         <div className="mt-8 flex justify-center md:hidden">
-          <div ref={paginationRef} className="swiper-pagination !static" />
+          <div
+            ref={paginationRef}
+            className={`swiper-pagination !static ${totalProperties <= 1 ? "hidden" : ""}`}
+          />
         </div>
       </div>
     </section>


### PR DESCRIPTION
## Summary
- only display desktop navigation controls when more than three properties are available and hide mobile pagination when a single property is shown
- update the carousel to keep swipe interactions for multiple mobile properties while only enabling navigation modules for larger desktop sets

## Testing
- not run (per instructions)

------
https://chatgpt.com/codex/tasks/task_e_68e48e98b6688323b8ae0f1c3c5cf66f