### PR TITLE
Fix pagination initialization guard in PropertyCarousel

### DIFF
--- a/src/components/FeaturedProperties/PropertyCarousel.tsx
+++ b/src/components/FeaturedProperties/PropertyCarousel.tsx
@@ -128,10 +128,16 @@ const PropertyCarousel = ({
 					navigation.nextEl = navigationNextRef.current;
 				}
 
-				if (typeof swiper.params.pagination !== "boolean") {
-					swiper.params.pagination.el = paginationRef.current;
-				}
-			}}
+                                if (
+                                        swiper.params.pagination &&
+                                        typeof swiper.params.pagination !== "boolean"
+                                ) {
+                                        const pagination = swiper.params.pagination;
+
+                                        pagination.el = paginationRef.current;
+                                        pagination.clickable = true;
+                                }
+                        }}
 			onSwiper={(swiper) => {
 				swiperRef.current = swiper;
 			}}


### PR DESCRIPTION
## Summary
- add a runtime check to ensure pagination params exist before assigning the pagination element
- keep pagination configuration clickable when the element ref is attached

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e49731f8408323a6181b245a2b8583