### PR TITLE
Allow carousel navigation refs to accept nullable elements

### DIFF
--- a/src/components/FeaturedProperties/PropertyCarousel.tsx
+++ b/src/components/FeaturedProperties/PropertyCarousel.tsx
@@ -29,10 +29,10 @@ export interface Property {
 }
 
 interface PropertyCarouselProps {
-	properties: Property[];
-	navigationPrevRef: RefObject<HTMLButtonElement>;
-	navigationNextRef: RefObject<HTMLButtonElement>;
-	paginationRef: RefObject<HTMLDivElement>;
+        properties: Property[];
+        navigationPrevRef: RefObject<HTMLButtonElement | null>;
+        navigationNextRef: RefObject<HTMLButtonElement | null>;
+        paginationRef: RefObject<HTMLDivElement | null>;
 }
 
 const PropertyCarousel = ({


### PR DESCRIPTION
## Summary
- update PropertyCarousel prop types to accept nullable navigation and pagination refs so they match useRef initial values

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e4988feb9c8323b735b03c38dac6e4