### PR TITLE
Center featured cards in highlighted properties section

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -87,11 +87,15 @@ html.gallery-modal-open body {
 }
 
 .swiper-wrapper {
-	overflow: visible !important;
+        overflow: visible !important;
 }
 
 .swiper-slide {
-	z-index: 50;
+        z-index: 50;
+}
+
+.featured-properties .featured-properties-wrapper-centered {
+        justify-content: center;
 }
 
 .card-3d {

--- a/src/components/FeaturedProperties/PropertyCarousel.tsx
+++ b/src/components/FeaturedProperties/PropertyCarousel.tsx
@@ -42,8 +42,9 @@ const PropertyCarousel = ({
 	paginationRef,
 }: PropertyCarouselProps) => {
 	const swiperRef = useRef<SwiperInstance | null>(null);
-	const totalProperties = properties.length;
-	const shouldLoop = totalProperties > 3;
+        const totalProperties = properties.length;
+        const shouldLoop = totalProperties > 3;
+        const shouldCenterSlides = totalProperties <= 2;
 	const slidesPerViewFor = (desired: number) => {
 		if (totalProperties <= 0) {
 			return 1;
@@ -99,9 +100,10 @@ const PropertyCarousel = ({
 	}, [shouldLoop, navigationPrevRef, navigationNextRef, paginationRef]);
 
 	return (
-		<Swiper
-			modules={[Navigation, Pagination]}
-			className="swiper mySwiper"
+                <Swiper
+                        modules={[Navigation, Pagination]}
+                        className={`swiper mySwiper w-full ${shouldCenterSlides ? "md:mx-auto md:max-w-5xl" : ""}`}
+                        wrapperClass={shouldCenterSlides ? "featured-properties-wrapper-centered" : undefined}
 			spaceBetween={30}
 			slidesPerView={1}
 			loop={shouldLoop}

--- a/src/components/FeaturedProperties/index.tsx
+++ b/src/components/FeaturedProperties/index.tsx
@@ -22,8 +22,8 @@ const FeaturedProperties = () => {
           Propiedades Destacadas
         </h2>
 
-        <div className="featured-properties relative mx-auto flex max-w-6xl flex-col items-center ">
-          <div className="swiper-container w-full border border-red-500 ">
+        <div className="featured-properties relative mx-auto flex max-w-6xl flex-col items-center">
+          <div className="swiper-container w-full">
             {isLoading && (
               <div className="flex h-56 items-center justify-center">
                 <p className="text-gray-500">Cargando propiedades…</p>


### PR DESCRIPTION
## Summary
- remove the debug borders around the featured properties carousel container
- adjust the carousel configuration to limit its width and center slides when only a couple of properties are available
- add styling to center the swiper wrapper when the width restriction is active

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e49a4d75e88323be4f4a20c6b9466d