### PR TITLE
Rename AWS environment variables for S3 configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,9 @@ This is a [Next.js](https://nextjs.org) project bootstrapped with [`create-next-
 
 Set the following variables to enable image delivery from Amazon S3:
 
-- `AWS_REGION`: AWS region where your public bucket lives.
-- `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY`: credentials with read access to the bucket.
-- `S3_PUBLIC_BUCKET`: name of the S3 bucket that stores public property images.
+- `REGION`: AWS region where your public bucket lives.
+- `ACCESS_KEY_ID` and `SECRET_ACCESS_KEY`: credentials with read access to the bucket.
+- `PUBLIC_BUCKET`: name of the S3 bucket that stores public property images.
 
 When a signed URL cannot be generated or an image key is missing, the UI will fall back to the default image defined by `FALLBACK_IMAGE`.
 

--- a/src/app/api/properties/route.ts
+++ b/src/app/api/properties/route.ts
@@ -3,7 +3,7 @@ import { getSignedUrl } from '@aws-sdk/s3-request-presigner';
 import { NextResponse } from 'next/server';
 
 import { prisma } from '@/lib/prisma';
-import { S3_PUBLIC_BUCKET, s3Client } from '@/lib/s3';
+import { PUBLIC_BUCKET, s3Client } from '@/lib/s3';
 
 const normalizeSlug = (value?: string | null) => {
   if (!value) {
@@ -41,12 +41,12 @@ export async function GET() {
           (inmueble.imagenes ?? []).map(async (imagen) => {
             let signedUrl: string | null = null;
 
-            if (imagen.s3Key && S3_PUBLIC_BUCKET) {
+            if (imagen.s3Key && PUBLIC_BUCKET) {
               try {
                 signedUrl = await getSignedUrl(
                   s3Client,
                   new GetObjectCommand({
-                    Bucket: S3_PUBLIC_BUCKET,
+                    Bucket: PUBLIC_BUCKET,
                     Key: imagen.s3Key,
                   }),
                   { expiresIn: 3600 },

--- a/src/lib/properties.ts
+++ b/src/lib/properties.ts
@@ -2,7 +2,7 @@ import { GetObjectCommand } from "@aws-sdk/client-s3";
 import { getSignedUrl } from "@aws-sdk/s3-request-presigner";
 
 import { prisma } from "./prisma";
-import { S3_PUBLIC_BUCKET, s3Client } from "@/lib/s3";
+import { PUBLIC_BUCKET, s3Client } from "@/lib/s3";
 
 export interface GetPropertyBySlugParams {
   slug: string;
@@ -61,12 +61,12 @@ const attachSignedUrls = async <
     (property.imagenes ?? []).map(async (imagen) => {
       let signedUrl: string | null = null;
 
-      if (imagen?.s3Key && S3_PUBLIC_BUCKET) {
+      if (imagen?.s3Key && PUBLIC_BUCKET) {
         try {
           signedUrl = await getSignedUrl(
             s3Client,
             new GetObjectCommand({
-              Bucket: S3_PUBLIC_BUCKET,
+              Bucket: PUBLIC_BUCKET,
               Key: imagen.s3Key,
             }),
             { expiresIn: 3600 },

--- a/src/lib/s3.ts
+++ b/src/lib/s3.ts
@@ -1,10 +1,10 @@
 import { S3Client } from "@aws-sdk/client-s3";
 
-const region = process.env.AWS_REGION;
-const accessKeyId = process.env.AWS_ACCESS_KEY_ID;
-const secretAccessKey = process.env.AWS_SECRET_ACCESS_KEY;
+const region = process.env.REGION;
+const accessKeyId = process.env.ACCESS_KEY_ID;
+const secretAccessKey = process.env.SECRET_ACCESS_KEY;
 
-export const S3_PUBLIC_BUCKET = process.env.S3_PUBLIC_BUCKET ?? "";
+export const PUBLIC_BUCKET = process.env.PUBLIC_BUCKET ?? "";
 
 export const s3Client = new S3Client({
   region,


### PR DESCRIPTION
## Summary
- update the S3 client configuration to read REGION, ACCESS_KEY_ID, SECRET_ACCESS_KEY, and PUBLIC_BUCKET
- adjust property APIs to use the renamed PUBLIC_BUCKET constant
- refresh the environment variable documentation to mention the new names

## Testing
- not run (per instructions)

------
https://chatgpt.com/codex/tasks/task_e_68e5d4998c208323b1a243f6945b6e5e