### PR TITLE
Refine property components typing and images

### DIFF
--- a/src/components/FeaturedProperties/PropertyCarousel.tsx
+++ b/src/components/FeaturedProperties/PropertyCarousel.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import Image from "next/image";
 import type { RefObject } from "react";
 import { useEffect, useRef } from "react";
 import type { Swiper as SwiperInstance } from "swiper";
@@ -93,12 +94,12 @@ const PropertyCarousel = ({
 				swiper.navigation.update();
 			}
 		} else {
-			if (swiper.navigation) {
-				try {
-					swiper.navigation.destroy();
-				} catch {}
-			}
-			swiper.params.navigation = false as any;
+                        if (swiper.navigation) {
+                                try {
+                                        swiper.navigation.destroy();
+                                } catch {}
+                        }
+                        swiper.params.navigation = false;
 		}
 
 		// Pagination dinámica (solo si hay 2+ propiedades)
@@ -117,18 +118,18 @@ const PropertyCarousel = ({
 				swiper.pagination.init();
 				swiper.pagination.render();
 				swiper.pagination.update();
-				paginationRef.current.style.display = ""; // visible
-			}
-		} else {
-			// ocultar bullets si solo hay 1
-			if (paginationRef.current)
-				paginationRef.current.style.display = "none";
-			if (swiper.pagination) {
-				try {
-					swiper.pagination.destroy();
-				} catch {}
-			}
-			swiper.params.pagination = false as any;
+                                paginationRef.current.style.display = ""; // visible
+                        }
+                } else {
+                        // ocultar bullets si solo hay 1
+                        if (paginationRef.current)
+                                paginationRef.current.style.display = "none";
+                        if (swiper.pagination) {
+                                try {
+                                        swiper.pagination.destroy();
+                                } catch {}
+                        }
+                        swiper.params.pagination = false;
 		}
 
 		swiper.update();
@@ -160,46 +161,46 @@ const PropertyCarousel = ({
 			centeredSlidesBounds
 			centerInsufficientSlides
 			watchOverflow
-			navigation={
-				showNav
-					? {
-							prevEl: navigationPrevRef.current,
-							nextEl: navigationNextRef.current,
-					  }
-					: false
-			}
-			pagination={
-				showPagination
-					? {
-							el: paginationRef.current,
-							clickable: true,
-					  }
-					: false
-			}
+                        navigation={
+                                showNav
+                                        ? {
+                                                  prevEl: navigationPrevRef.current,
+                                                  nextEl: navigationNextRef.current,
+                                          }
+                                        : false
+                        }
+                        pagination={
+                                showPagination
+                                        ? {
+                                                  el: paginationRef.current,
+                                                  clickable: true,
+                                          }
+                                        : false
+                        }
 			onBeforeInit={(swiper) => {
 				swiperRef.current = swiper;
 
-				if (
-					showNav &&
-					swiper.params.navigation &&
-					typeof swiper.params.navigation !== "boolean"
-				) {
-					swiper.params.navigation.prevEl = navigationPrevRef.current;
-					swiper.params.navigation.nextEl = navigationNextRef.current;
-				} else {
-					swiper.params.navigation = false as any;
-				}
+                                if (
+                                        showNav &&
+                                        swiper.params.navigation &&
+                                        typeof swiper.params.navigation !== "boolean"
+                                ) {
+                                        swiper.params.navigation.prevEl = navigationPrevRef.current;
+                                        swiper.params.navigation.nextEl = navigationNextRef.current;
+                                } else {
+                                        swiper.params.navigation = false;
+                                }
 
-				if (
-					showPagination &&
-					swiper.params.pagination &&
-					typeof swiper.params.pagination !== "boolean"
-				) {
-					swiper.params.pagination.el = paginationRef.current;
-					swiper.params.pagination.clickable = true;
-				} else {
-					swiper.params.pagination = false as any;
-				}
+                                if (
+                                        showPagination &&
+                                        swiper.params.pagination &&
+                                        typeof swiper.params.pagination !== "boolean"
+                                ) {
+                                        swiper.params.pagination.el = paginationRef.current;
+                                        swiper.params.pagination.clickable = true;
+                                } else {
+                                        swiper.params.pagination = false;
+                                }
 			}}
 			onSwiper={(swiper) => {
 				swiperRef.current = swiper;
@@ -225,13 +226,14 @@ const PropertyCarousel = ({
 					>
 						<div className="card-3d w-full md:w-[22rem] lg:w-[24rem] h-full flex flex-col overflow-hidden rounded-2xl border border-white/60 bg-white/90 shadow-none backdrop-blur">
 							{/* Imagen con alto uniforme: relación 16:9 en todos los breakpoints */}
-							<div className="relative w-full aspect-[16/9] overflow-hidden">
-								<img
-									src={property.coverImageUrl}
-									alt={property.title}
-									className="absolute inset-0 h-full w-full object-cover"
-									loading="lazy"
-								/>
+                                                        <div className="relative w-full aspect-[16/9] overflow-hidden">
+                                                                <Image
+                                                                        fill
+                                                                        src={property.coverImageUrl}
+                                                                        alt={property.title}
+                                                                        className="object-cover"
+                                                                        sizes="(max-width: 768px) 100vw, 352px"
+                                                                />
 								<span className="absolute left-3 top-3 rounded-full bg-[var(--lime)] px-3 py-1 text-xs font-bold text-black">
 									{statusLabel}
 								</span>

--- a/src/components/inmuebles/MobileGalleryModal.tsx
+++ b/src/components/inmuebles/MobileGalleryModal.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import Image from "next/image";
 import { AnimatePresence, motion } from "framer-motion";
 
 type GalleryImage = {
@@ -44,9 +45,14 @@ const MobileGalleryModal = ({
 	showPrevious,
 	title,
 }: MobileGalleryModalProps) => {
-	const activeDirection = direction ?? "next";
+        const activeDirection = direction ?? "next";
+        const activeImage = galleryItems[activeIndex];
 
-	return (
+        if (!activeImage) {
+                return null;
+        }
+
+        return (
 		<motion.div
 			className="property-gallery-modal-mobile fixed inset-0 z-50 flex min-h-[100svh] w-full bg-black/95"
 			style={{
@@ -105,48 +111,46 @@ const MobileGalleryModal = ({
 				</header>
 
 				<div className="relative flex flex-1 items-center justify-center overflow-hidden">
-					<AnimatePresence
-						initial={false}
-						custom={activeDirection}
-						mode="wait"
-					>
-						<motion.img
-							key={galleryItems[activeIndex]?.url}
-							src={galleryItems[activeIndex]?.url}
-							alt={
-								galleryItems[activeIndex]?.alt ??
-								title ??
-								"Imagen del inmueble"
-							}
-							className="max-h-full w-full max-w-full select-none object-contain"
-							custom={activeDirection}
-							variants={imageVariants}
-							initial="enter"
-							animate="center"
-							exit="exit"
-							transition={{
-								type: "spring",
-								stiffness: 400,
-								damping: 32,
-							}}
-							drag="x"
-							dragConstraints={{ left: 0, right: 0 }}
-							dragElastic={0.2}
-							onDragEnd={(_, info) => {
-								if (
-									info.offset.x < -80 ||
-									info.velocity.x < -0.5
-								) {
-									showNext();
-								} else if (
-									info.offset.x > 80 ||
-									info.velocity.x > 0.5
-								) {
-									showPrevious();
-								}
-							}}
-						/>
-					</AnimatePresence>
+                                        <AnimatePresence initial={false} custom={activeDirection} mode="wait">
+                                                <motion.div
+                                                        key={activeImage.url}
+                                                        className="relative h-full w-full max-h-full max-w-full"
+                                                        custom={activeDirection}
+                                                        variants={imageVariants}
+                                                        initial="enter"
+                                                        animate="center"
+                                                        exit="exit"
+                                                        transition={{
+                                                                type: "spring",
+                                                                stiffness: 400,
+                                                                damping: 32,
+                                                        }}
+                                                        drag="x"
+                                                        dragConstraints={{ left: 0, right: 0 }}
+                                                        dragElastic={0.2}
+                                                        onDragEnd={(_, info) => {
+                                                                if (
+                                                                        info.offset.x < -80 ||
+                                                                        info.velocity.x < -0.5
+                                                                ) {
+                                                                        showNext();
+                                                                } else if (
+                                                                        info.offset.x > 80 ||
+                                                                        info.velocity.x > 0.5
+                                                                ) {
+                                                                        showPrevious();
+                                                                }
+                                                        }}
+                                                >
+                                                        <Image
+                                                                fill
+                                                                src={activeImage.url}
+                                                                alt={activeImage.alt ?? title ?? "Imagen del inmueble"}
+                                                                className="select-none object-contain"
+                                                                sizes="100vw"
+                                                        />
+                                                </motion.div>
+                                        </AnimatePresence>
 
 					{galleryItems.length > 1 && (
 						<>

--- a/src/components/inmuebles/PropertyCard.tsx
+++ b/src/components/inmuebles/PropertyCard.tsx
@@ -1,3 +1,4 @@
+import Image from "next/image";
 import Link from "next/link";
 
 import { FALLBACK_IMAGE } from "@/components/FeaturedProperties/useProperties";
@@ -53,12 +54,18 @@ const PropertyCard = ({ property, viewMode }: PropertyCardProps) => {
   const imageWrapperClasses = isListMode
     ? "relative w-full shrink-0 aspect-[4/3] md:h-full md:w-5/12 md:aspect-auto"
     : "relative w-full shrink-0 aspect-[4/3]";
-  const imageClasses = "h-full w-full object-cover";
+  const imageClasses = "object-cover";
 
   return (
     <article className={articleClasses}>
       <div className={imageWrapperClasses}>
-        <img src={imageUrl} alt={property.title} className={imageClasses} />
+        <Image
+          fill
+          src={imageUrl}
+          alt={property.title}
+          className={imageClasses}
+          sizes="(max-width: 768px) 100vw, (max-width: 1200px) 50vw, 33vw"
+        />
 
         <div className="absolute left-3 top-3 flex flex-wrap gap-2">
           <span className="rounded-full bg-[var(--lime)] px-3 py-1 text-xs font-semibold text-black">

--- a/src/components/inmuebles/PropertyGallery.tsx
+++ b/src/components/inmuebles/PropertyGallery.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import Image from "next/image";
 import { AnimatePresence, motion } from "framer-motion";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { createPortal } from "react-dom";
@@ -44,12 +45,17 @@ type GalleryModalContentProps = {
 const DesktopGalleryModal = ({
         activeIndex,
         closeModal,
-        direction: _direction,
         galleryItems,
         showNext,
         showPrevious,
         title,
 }: GalleryModalContentProps) => {
+        const activeImage = galleryItems[activeIndex];
+
+        if (!activeImage) {
+                return null;
+        }
+
         return (
                 <motion.div
                         className="property-gallery-modal fixed inset-0 z-50 flex min-h-[100svh] w-full items-center justify-center bg-black/95"
@@ -108,22 +114,26 @@ const DesktopGalleryModal = ({
                                 </header>
 
                                 <div className="relative flex flex-1 items-center justify-center bg-gradient-to-b from-black/30 via-black/50 to-black/70 px-3 py-6 sm:px-8 sm:py-10">
-                                        <motion.img
-                                                key={galleryItems[activeIndex]?.url}
-                                                src={galleryItems[activeIndex]?.url}
-                                                alt={
-                                                        galleryItems[activeIndex]?.alt ??
-                                                        title ??
-                                                        "Imagen del inmueble"
-                                                }
-                                                className="max-h-full w-full max-w-full cursor-zoom-in object-contain"
-                                                initial={{ opacity: 0, y: 20 }}
-                                                animate={{ opacity: 1, y: 0 }}
-                                                transition={{
-                                                        duration: 0.4,
-                                                        ease: "easeOut",
-                                                }}
-                                        />
+                                        {activeImage && (
+                                                <motion.div
+                                                        key={activeImage.url}
+                                                        className="relative flex h-full w-full items-center justify-center"
+                                                        initial={{ opacity: 0, y: 20 }}
+                                                        animate={{ opacity: 1, y: 0 }}
+                                                        transition={{
+                                                                duration: 0.4,
+                                                                ease: "easeOut",
+                                                        }}
+                                                >
+                                                        <Image
+                                                                fill
+                                                                src={activeImage.url}
+                                                                alt={activeImage.alt ?? title ?? "Imagen del inmueble"}
+                                                                className="object-contain"
+                                                                sizes="(max-width: 1024px) 90vw, 960px"
+                                                        />
+                                                </motion.div>
+                                        )}
 
                                         {galleryItems.length > 1 && (
                                                 <>
@@ -489,25 +499,26 @@ const PropertyGallery = ({ images, title }: PropertyGalleryProps) => {
 									}
 								}}
 							>
-								<motion.div
-									className="w-full overflow-hidden aspect-[16/11] sm:aspect-[16/9]"
-									whileHover={{ scale: 1.03 }}
-									transition={{ duration: 0.4 }}
-								>
-									<img
-										src={image.url}
-										alt={
-											image.alt ??
-											title ??
-											"Imagen del inmueble"
-										}
-										className="h-full w-full object-cover transition-transform duration-700 ease-out group-hover:scale-110"
-										style={{
-											background: shimmerBackground,
-										}}
-										loading="lazy"
-									/>
-								</motion.div>
+                                                                <motion.div
+                                                                        className="relative w-full overflow-hidden aspect-[16/11] sm:aspect-[16/9]"
+                                                                        whileHover={{ scale: 1.03 }}
+                                                                        transition={{ duration: 0.4 }}
+                                                                >
+                                                                        <Image
+                                                                                fill
+                                                                                src={image.url}
+                                                                                alt={
+                                                                                        image.alt ??
+                                                                                        title ??
+                                                                                        "Imagen del inmueble"
+                                                                                }
+                                                                                className="object-cover transition-transform duration-700 ease-out group-hover:scale-110"
+                                                                                style={{
+                                                                                        background: shimmerBackground,
+                                                                                }}
+                                                                                sizes="(max-width: 768px) 100vw, (max-width: 1280px) 70vw, 960px"
+                                                                        />
+                                                                </motion.div>
 								<motion.div className="pointer-events-none absolute inset-x-0 bottom-0 h-24 bg-gradient-to-t from-black/60 via-black/10 to-transparent" />
 							</motion.figure>
 						</SwiperSlide>

--- a/src/lib/properties.ts
+++ b/src/lib/properties.ts
@@ -1,119 +1,142 @@
 import { GetObjectCommand } from "@aws-sdk/client-s3";
 import { getSignedUrl } from "@aws-sdk/s3-request-presigner";
+import { Prisma } from "@prisma/client";
+import type { InmuebleImagen, PrismaClient } from "@prisma/client";
 
 import { prisma } from "./prisma";
 import { PUBLIC_BUCKET, s3Client } from "@/lib/s3";
 
 export interface GetPropertyBySlugParams {
-  slug: string;
-  id?: string | number | bigint;
+        slug: string;
+        id?: string | number | bigint;
 }
 
-const propertyInclude = {
-  estatus: true,
-  imagenes: {
-    orderBy: [{ orden: "asc" }, { createdAt: "asc" }],
-  },
-} as const;
+const propertyInclude = Prisma.validator<Prisma.InmuebleInclude>()({
+        estatus: true,
+        imagenes: {
+                orderBy: [
+                        { orden: "asc" as const },
+                        { createdAt: "asc" as const },
+                ],
+        },
+});
+
+type PropertyWithRelations = Prisma.InmuebleGetPayload<{ include: typeof propertyInclude }>;
+type MetadataRecord = Record<string, unknown>;
+type PropertyWithMetadata = PropertyWithRelations & { metadata?: MetadataRecord[] };
+type ImageWithSignedUrl = Omit<InmuebleImagen, "url"> & {
+        url: string | null;
+        signedUrl: string | null;
+};
+type PropertyWithSignedImages = Omit<PropertyWithMetadata, "imagenes"> & {
+        imagenes: ImageWithSignedUrl[];
+};
+
+type MetadataOrderBy = { orden?: "asc" | "desc"; createdAt?: "asc" | "desc" };
+type MetadataDelegate = {
+        findMany?: (args: { where: { inmuebleId: bigint }; orderBy?: MetadataOrderBy[] }) => Promise<MetadataRecord[]>;
+};
 
 const normalizeId = (id: string | number | bigint) => {
-  if (typeof id === "bigint") {
-    return id;
-  }
-
-  if (typeof id === "number") {
-    return BigInt(id);
-  }
-
-  return BigInt(id);
-};
-
-const attachMetadata = async <T extends { id: bigint } | null>(property: T) => {
-  if (!property) {
-    return property;
-  }
-
-  const metadataDelegate = (prisma as any).inmuebleMetadata;
-
-  if (metadataDelegate?.findMany) {
-    const metadata = await metadataDelegate.findMany({
-      where: { inmuebleId: property.id } as any,
-      orderBy: { orden: "asc" } as any,
-    });
-
-    return {
-      ...property,
-      metadata,
-    };
-  }
-
-  return property;
-};
-
-const attachSignedUrls = async <
-  T extends { imagenes?: Array<Record<string, any>> } | null,
->(property: T) => {
-  if (!property) {
-    return property;
-  }
-
-  const imagenes = await Promise.all(
-    (property.imagenes ?? []).map(async (imagen) => {
-      let signedUrl: string | null = null;
-
-      if (imagen?.s3Key && PUBLIC_BUCKET) {
-        try {
-          signedUrl = await getSignedUrl(
-            s3Client,
-            new GetObjectCommand({
-              Bucket: PUBLIC_BUCKET,
-              Key: imagen.s3Key,
-            }),
-            { expiresIn: 3600 },
-          );
-        } catch (error) {
-          console.error(
-            `Error generating signed URL for image ${imagen.id} with key ${imagen.s3Key}`,
-            error,
-          );
+        if (typeof id === "bigint") {
+                return id;
         }
-      }
 
-      const url = signedUrl ?? imagen?.url ?? imagen?.path ?? null;
+        if (typeof id === "number") {
+                return BigInt(id);
+        }
 
-      return {
-        ...imagen,
-        signedUrl,
-        url,
-      };
-    }),
-  );
-
-  return {
-    ...(property as Record<string, any>),
-    imagenes,
-  } as T;
+        return BigInt(id);
 };
 
-export const getPropertyBySlug = async ({ slug, id }: GetPropertyBySlugParams) => {
-  const propertyBySlug = await prisma.inmueble.findUnique({
-    where: { slug } as any,
-    include: propertyInclude,
-  } as any);
+const attachMetadata = async (
+        property: PropertyWithRelations | null
+): Promise<PropertyWithMetadata | null> => {
+        if (!property) {
+                return property;
+        }
 
-  if (propertyBySlug || id === undefined) {
-    const propertyWithMetadata = await attachMetadata(propertyBySlug as any);
+        const metadataDelegate = (prisma as PrismaClient & { inmuebleMetadata?: MetadataDelegate }).inmuebleMetadata;
 
-    return attachSignedUrls(propertyWithMetadata as any);
-  }
+        if (!metadataDelegate?.findMany) {
+                return property;
+        }
 
-  const normalizedId = normalizeId(id);
-  const propertyById = await prisma.inmueble.findUnique({
-    where: { id: normalizedId } as any,
-    include: propertyInclude,
-  } as any);
+        const metadata = await metadataDelegate.findMany({
+                where: { inmuebleId: property.id },
+                orderBy: [{ orden: "asc" }],
+        });
 
-  const propertyWithMetadata = await attachMetadata(propertyById as any);
+        return {
+                ...property,
+                metadata,
+        };
+};
 
-  return attachSignedUrls(propertyWithMetadata as any);
+const attachSignedUrls = async (
+        property: PropertyWithMetadata | null
+): Promise<PropertyWithSignedImages | null> => {
+        if (!property) {
+                return property;
+        }
+
+        const imagenesWithSignedUrls: ImageWithSignedUrl[] = await Promise.all(
+                (property.imagenes ?? []).map(async (imagen) => {
+                        let signedUrl: string | null = null;
+
+                        if (imagen.s3Key && PUBLIC_BUCKET) {
+                                try {
+                                        signedUrl = await getSignedUrl(
+                                                s3Client,
+                                                new GetObjectCommand({
+                                                        Bucket: PUBLIC_BUCKET,
+                                                        Key: imagen.s3Key,
+                                                }),
+                                                { expiresIn: 3600 }
+                                        );
+                                } catch (error) {
+                                        console.error(
+                                                `Error generating signed URL for image ${imagen.id} with key ${imagen.s3Key}`,
+                                                error
+                                        );
+                                }
+                        }
+
+                        const url = signedUrl ?? imagen.url ?? imagen.path ?? null;
+
+                        return {
+                                ...imagen,
+                                signedUrl,
+                                url,
+                        };
+                })
+        );
+
+        return {
+                ...property,
+                imagenes: imagenesWithSignedUrls,
+        };
+};
+
+export const getPropertyBySlug = async ({ slug, id }: GetPropertyBySlugParams): Promise<PropertyWithSignedImages | null> => {
+        const propertyBySlug = await prisma.inmueble.findUnique({
+                where: { slug },
+                include: propertyInclude,
+        });
+
+        if (propertyBySlug || id === undefined) {
+                const propertyWithMetadata = await attachMetadata(propertyBySlug);
+
+                return attachSignedUrls(propertyWithMetadata);
+        }
+
+        const normalizedId = normalizeId(id);
+        const propertyById = await prisma.inmueble.findUnique({
+                where: { id: normalizedId },
+                include: propertyInclude,
+        });
+
+        const propertyWithMetadata = await attachMetadata(propertyById);
+
+        return attachSignedUrls(propertyWithMetadata);
 };


### PR DESCRIPTION
## Summary
- tighten AboutSection review parsing to avoid `any` usage
- update property carousel, cards, and galleries to use `next/image` and remove `any` casts from swiper configuration
- strengthen property data helpers with concrete Prisma typing and signed URL mapping

## Testing
- not run (per instructions)

------
https://chatgpt.com/codex/tasks/task_e_68e5d7248d28832393783ab78d66f12b