### PR TITLE
Fix type annotations in property slug page

### DIFF
--- a/src/lib/properties.ts
+++ b/src/lib/properties.ts
@@ -21,14 +21,14 @@ const propertyInclude = Prisma.validator<Prisma.InmuebleInclude>()({
         },
 });
 
-type PropertyWithRelations = Prisma.InmuebleGetPayload<{ include: typeof propertyInclude }>;
-type MetadataRecord = Record<string, unknown>;
+export type PropertyWithRelations = Prisma.InmuebleGetPayload<{ include: typeof propertyInclude }>;
+export type MetadataRecord = Record<string, unknown>;
 type PropertyWithMetadata = PropertyWithRelations & { metadata?: MetadataRecord[] };
-type ImageWithSignedUrl = Omit<InmuebleImagen, "url"> & {
+export type ImageWithSignedUrl = Omit<InmuebleImagen, "url"> & {
         url: string | null;
         signedUrl: string | null;
 };
-type PropertyWithSignedImages = Omit<PropertyWithMetadata, "imagenes"> & {
+export type PropertyWithSignedImages = Omit<PropertyWithMetadata, "imagenes"> & {
         imagenes: ImageWithSignedUrl[];
 };
 


### PR DESCRIPTION
## Summary
- export the property and image helper types from the properties library
- replace any usages on the inmueble slug page with the shared types and rely on typed prisma queries

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e5dba07a548323b4d54aa3ad1df010