### PR TITLE
Fix properties API city field mapping

### DIFF
--- a/src/app/api/properties/route.ts
+++ b/src/app/api/properties/route.ts
@@ -118,7 +118,7 @@ export async function GET() {
           price: inmueble.precio.toNumber(),
           address: inmueble.direccion,
           neighborhood: inmueble.colonia,
-          city: inmueble.ciudad,
+          city: inmueble.municipio,
           state: inmueble.estado,
           postalCode: inmueble.codigoPostal,
           location: {


### PR DESCRIPTION
## Summary
- use the municipio field when populating the city attribute in the properties API response

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e5ddded0e08323823304efd0b2d71c