### PR TITLE
Handle nullable createdAt when serializing properties

### DIFF
--- a/src/app/api/properties/route.ts
+++ b/src/app/api/properties/route.ts
@@ -145,7 +145,9 @@ export async function GET() {
               }
             : null,
           images,
-          createdAt: inmueble.createdAt.toISOString(),
+          createdAt: inmueble.createdAt
+            ? inmueble.createdAt.toISOString()
+            : null,
           updatedAt: inmueble.updatedAt.toISOString(),
         };
       }),


### PR DESCRIPTION
## Summary
- guard against null property creation dates before serializing them to ISO strings

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e5e59ce8648323ab2f5ddbdf06f576