### PR TITLE
Handle nullable updatedAt in properties API

### DIFF
--- a/src/app/api/properties/route.ts
+++ b/src/app/api/properties/route.ts
@@ -148,7 +148,9 @@ export async function GET() {
           createdAt: inmueble.createdAt
             ? inmueble.createdAt.toISOString()
             : null,
-          updatedAt: inmueble.updatedAt.toISOString(),
+          updatedAt: inmueble.updatedAt
+            ? inmueble.updatedAt.toISOString()
+            : null,
         };
       }),
     );


### PR DESCRIPTION
## Summary
- guard against null updatedAt values when serializing properties

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e5e6891f5c83238baa36fb4bf7a7de