### PR TITLE
Fix Open Graph metadata image handling

### DIFF
--- a/src/app/inmuebles/[slug]/page.tsx
+++ b/src/app/inmuebles/[slug]/page.tsx
@@ -24,21 +24,23 @@ type PropertyPageProps = {
 };
 
 const buildOpenGraphImages = (property: PropertyWithSignedImages | null) => {
-  return (property?.imagenes ?? [])
-    .map((image) => {
-      const imageMetadata = (image.metadata ?? {}) as { alt?: string };
-      const url = image.signedUrl ?? image.url ?? image.path;
+  const openGraphImages = (property?.imagenes ?? []).flatMap((image) => {
+    const imageMetadata = (image.metadata ?? {}) as { alt?: string };
+    const url = image.signedUrl ?? image.url ?? image.path;
 
-      if (!url) {
-        return null;
-      }
+    if (!url) {
+      return [] as const;
+    }
 
-      return {
+    return [
+      {
         url,
         alt: imageMetadata?.alt ?? property?.titulo ?? "Imagen del inmueble",
-      };
-    })
-    .filter((image: { url: string } | null): image is { url: string; alt?: string } => Boolean(image));
+      },
+    ] as const;
+  });
+
+  return openGraphImages.length > 0 ? openGraphImages : undefined;
 };
 
 export async function generateStaticParams() {


### PR DESCRIPTION
## Summary
- update the Open Graph image builder to drop invalid entries without leaving null values
- return undefined when no valid images exist so the metadata type matches Next.js expectations

## Testing
- not run (per instructions)


------
https://chatgpt.com/codex/tasks/task_e_68e5e924e19883239460f2bae0334b20