### PR TITLE
Fix review mapping type guard

### DIFF
--- a/src/components/AboutSection.tsx
+++ b/src/components/AboutSection.tsx
@@ -81,7 +81,7 @@ const AboutSection = () => {
                                                         starRating,
                                                 };
                                         })
-                                        .filter((item): item is Review => Boolean(item));
+                                        .filter((item): item is Review => item !== null);
 
 				const shuffledReviews = mappedReviews
 					.map((item) => ({ item, sortKey: Math.random() }))


### PR DESCRIPTION
## Summary
- ensure the review mapping filter removes null values with a type predicate

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e5ea3d4ad48323b761e3fd94f9f804