### PR TITLE
Handle database outages gracefully on property pages

### DIFF
--- a/src/app/inmuebles/[slug]/page.tsx
+++ b/src/app/inmuebles/[slug]/page.tsx
@@ -44,15 +44,21 @@ const buildOpenGraphImages = (property: PropertyWithSignedImages | null) => {
 };
 
 export async function generateStaticParams() {
-  const properties = await prisma.inmueble.findMany({
-    select: { slug: true },
-    where: { slug: { not: null } },
-  });
+  try {
+    const properties = await prisma.inmueble.findMany({
+      select: { slug: true },
+      where: { slug: { not: null } },
+    });
 
-  return properties
-    .map((property) => property.slug)
-    .filter((slug: string | null | undefined): slug is string => Boolean(slug))
-    .map((slug) => ({ slug }));
+    return properties
+      .map((property) => property.slug)
+      .filter((slug: string | null | undefined): slug is string => Boolean(slug))
+      .map((slug) => ({ slug }));
+  } catch (error) {
+    console.error("Error generating static params for properties", error);
+
+    return [];
+  }
 }
 
 export async function generateMetadata({ params }: PropertyPageProps): Promise<Metadata> {


### PR DESCRIPTION
## Summary
- wrap the property static params generator in a safe guard so builds do not fail when the database is offline
- add defensive error handling when loading property details and metadata to return null instead of throwing

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e5ecdc4c1c8323b669f0da92428201