### PR TITLE
Update footer attribution text

### DIFF
--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -17,14 +17,13 @@ const Footer = () => {
                                 </div>
 
                                 <p className="text-sm">
-                                        Desarrollado y diseñado por{" "}
                                         <a
                                                 href="https://alfgow.app"
                                                 target="_blank"
                                                 rel="noopener noreferrer"
                                                 className="text-gray-200 transition hover:text-white"
                                         >
-                                                alfgow
+                                                &lt;alfgow/&gt;
                                         </a>
                                 </p>
                         </div>


### PR DESCRIPTION
## Summary
- replace the footer attribution with a linked "<alfgow/>" label while preserving the existing link target

## Testing
- not run (per instructions)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691e11e39de08323bb0b025283d46bc4)