### PR TITLE
Fix main CI trigger and gate production deployment

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,8 @@
 name: CI
 
 on:
+  push:
+    branches: [main]
   pull_request:
   workflow_call:
   workflow_dispatch:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,8 +1,9 @@
 name: Deploy production
 
 on:
-  push:
-    branches: [main]
+  workflow_run:
+    workflows: [CI]
+    types: [completed]
   workflow_dispatch:
 
 permissions:
@@ -13,13 +14,15 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
-  ci:
-    uses: ./.github/workflows/ci.yml
-
   deploy:
-    needs: ci
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      (github.event.workflow_run.conclusion == 'success' &&
+      github.event.workflow_run.head_branch == 'main')
     runs-on: ubuntu-latest
     environment: production
+    env:
+      TARGET_SHA: ${{ github.event.workflow_run.head_sha || github.sha }}
     steps:
       - name: Connect to the private network
         uses: tailscale/github-action@v3
@@ -42,5 +45,4 @@ jobs:
         env:
           VPS_HOST: ${{ secrets.VPS_TAILSCALE_HOST }}
           VPS_USER: ${{ secrets.VPS_SSH_USER }}
-          TARGET_SHA: ${{ github.sha }}
         run: ssh "$VPS_USER@$VPS_HOST" "/opt/inmobiliaria-frontend/scripts/deploy.sh '$TARGET_SHA'"

--- a/README.md
+++ b/README.md
@@ -45,10 +45,11 @@ En Linux, el compose usa `network_mode: host` para que el frontend vea el mismo 
 
 ## CI/CD
 
-Los pull requests ejecutan Prisma, una instancia PostgreSQL efímera, lint,
-TypeScript y el build de producción. Cada push a `main` reutiliza ese mismo CI y,
-si termina correctamente, despliega el SHA exacto por Tailscale y SSH mediante
-`scripts/deploy.sh`.
+Los pull requests y cada push a `main` ejecutan Prisma, una instancia PostgreSQL
+efímera, lint, TypeScript y el build de producción. Cuando el workflow `CI` de
+`main` termina correctamente, `Deploy production` despliega el SHA exacto que fue
+validado por Tailscale y SSH mediante `scripts/deploy.sh`. También es posible
+ejecutar ambos workflows manualmente desde GitHub Actions.
 
 El environment `production` de GitHub necesita estos secrets:
 


### PR DESCRIPTION
### Motivation

- El workflow de `CI` no se disparaba en `push` sobre `main`, por lo que los pushes directos no generaban una ejecución independiente de validación y la relación CI→CD quedaba ambigua. ⚠️

- Se quería garantizar que solo se despliegue el `SHA` que fue validado por la ejecución de `CI` sobre `main`. ✅

### Description

- Añadí el trigger `push: branches: [main]` en `.github/workflows/ci.yml` para ejecutar CI en cada push a `main`.

- Reemplacé el `push` directo en `.github/workflows/deploy.yml` por `workflow_run: workflows: [CI] types: [completed]` y eliminé la reutilización directa de la job `ci` para que el despliegue espere a la finalización del `CI`.

- Añadí una condición `if` en el job `deploy` para permitir la ejecución manual (`workflow_dispatch`) o ejecución automática solo cuando el `workflow_run` de `CI` terminó `success` y la rama validada fue `main`, y fijé `TARGET_SHA` a `github.event.workflow_run.head_sha || github.sha` para desplegar exactamente el commit validado.

- Actualicé `README.md` para documentar la secuencia `push → CI → Deploy production` y los secrets necesarios para `production`.

### Testing

- Ejecuté `npm run lint` y la tarea finalizó correctamente. ✅

- Ejecuté `npm run typecheck` (`tsc --noEmit`) y la tarea finalizó correctamente. ✅

- Ejecuté `git diff --check` y `git status` para verificar el árbol; los cambios fueron committeados como `fix: trigger CI before production deployment`. ✅

- Intenté `npm run build`, pero la build falló en este entorno al no poder descargar Google Fonts (error de red), por lo que la construcción completa no pudo validarse aquí. ⚠️

- Intenté validar workflows con `actionlint` usando `go run`, pero la descarga de `actionlint` falló por un `Forbidden` desde `proxy.golang.org` en este entorno, así que la comprobación automática no pudo completarse. ⚠️

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6cbcdee63c8323b5f43f136dc19bc2)